### PR TITLE
Add implement box translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,6 @@ nia.cache
 nlia.cache
 nra.cache
 
-## extraction output
-*.out
-
 ## Dune build directory
 _build/
 
@@ -68,22 +65,21 @@ _build/
 .history
 
 ## Test files
-theories/test
 *.ast
+*.tast
 !examples/*.ast
-*.wasm
-!examples/*.wasm
-*.cwasm
-!examples/*.cwasm
-*.rs
-!examples/*.rs
-*.elm
-!examples/*.elm
-*.c
-!examples/*.c
-*.h
-!examples/*.h
+!examples/*.tast
 
 examples/**/*.txt
 examples/**/*.v
 examples/**/*.anf
+
+## Extraction output
+*.out
+*.wasm
+*.cwasm
+*.rs
+*.elm
+*.c
+*.h
+*.mlf

--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,7 @@ theories/EvalBox.v
 theories/CoqToLambdaBox.v
 theories/TypedTransforms.v
 theories/CertiCoqPipeline.v
+theories/ErasurePipeline.v
 theories/LambdaBoxToWasm.v
 theories/LambdaBoxToRust.v
 theories/LambdaBoxToElm.v

--- a/bin/compile.ml
+++ b/bin/compile.ml
@@ -156,6 +156,7 @@ let mk_copts opts copts =
 let compile_wasm opts eopts copts f =
   let p = get_ast opts eopts f in
   print_endline "Compiling:";
+  let p = LambdaBox.ErasurePipeline.implement_box agda_eflags p in
   let p = l_box_to_wasm (mk_copts opts copts) p in
   match p with
   | (CompM.Ret prg, dbg) ->
@@ -203,6 +204,7 @@ let compile_elm opts eopts f =
 let eval_box opts eopts copts anf f =
   let p = get_ast opts eopts f in
   print_endline "Evaluating:";
+  let p = LambdaBox.ErasurePipeline.implement_box agda_eflags p in
   let p = Eval.eval (mk_copts opts copts) anf p in
   match p with
   | (CompM.Ret t, dbg) ->
@@ -226,6 +228,7 @@ let printCProg prog names (dest : string) (imports : import list) =
 let compile_c opts eopts copts f =
   let p = get_ast opts eopts f in
   print_endline "Compiling:";
+  let p = LambdaBox.ErasurePipeline.implement_box agda_eflags p in
   let p = l_box_to_c (mk_copts opts copts) p in
   match p with
   | (CompM.Ret ((nenv, header), prg), dbg) ->
@@ -246,6 +249,7 @@ let compile_c opts eopts copts f =
 let compile_anf opts eopts copts f =
   let p = get_ast opts eopts f in
   print_endline "Compiling:";
+  let p = LambdaBox.ErasurePipeline.implement_box agda_eflags p in
   let p = LambdaBox.CertiCoqPipeline.show_IR (mk_copts opts copts) p in
   match p with
   | (CompM.Ret prg, dbg) ->

--- a/theories/ErasurePipeline.v
+++ b/theories/ErasurePipeline.v
@@ -1,0 +1,25 @@
+From MetaCoq.Erasure Require Import EImplementBox.
+From MetaCoq.Erasure Require Import EProgram.
+
+From MetaCoq.Common Require Import Transform.
+From MetaCoq.Utils Require Import bytestring.
+Import Transform.
+
+Local Open Scope bs.
+
+Program Definition implement_box_transformation efl :
+  Transform.t _ _ EAst.term EAst.term _ _ (eval_eprogram block_wcbv_flags) (eval_eprogram block_wcbv_flags) :=
+  {| name := "implementing box";
+    transform p _ := EImplementBox.implement_box_program p ;
+    pre p := True ;
+    post p := wf_eprogram (switch_off_box efl) p ;
+    obseq p hp p' v v' := v' = implement_box v |}.
+Next Obligation.
+Admitted.
+Next Obligation.
+Admitted.
+
+Axiom trust_coq_kernel : forall p efl, pre (implement_box_transformation efl) p.
+
+Definition implement_box {efl} p :=
+  run (implement_box_transformation efl) p (trust_coq_kernel p efl).

--- a/theories/Extraction.v
+++ b/theories/Extraction.v
@@ -1,6 +1,7 @@
 From MetaCoq.Erasure Require EAst.
 From LambdaBox Require CheckWf.
 From LambdaBox Require EvalBox.
+From LambdaBox Require ErasurePipeline.
 Local Unset Universe Checking. (* TODO: fix universe inconsistency *)
 From LambdaBox Require Translations.
 Local Set Universe Checking.
@@ -78,7 +79,7 @@ Separate Extraction Translations.l_box_to_wasm CertiCoqPipeline.show_IR CertiCoq
                     Translations.l_box_to_elm LambdaBoxToElm.default_remaps LambdaBoxToElm.default_preamble
                     Translations.l_box_to_c
                     Translations.l_box_to_ocaml
-                    TypedTransforms.mk_params
+                    TypedTransforms.mk_params ErasurePipeline.implement_box
                     EvalBox.eval
                     CheckWf.check_wf_program CheckWf.CheckWfExAst.check_wf_typed_program CheckWf.agda_eflags CheckWf.agda_typed_eflags
                     Serialize.program_of_string Serialize.global_env_of_string Serialize.kername_of_string Serialize.string_of_error


### PR DESCRIPTION
Replace $\square$ with a concrete implementation (`fix f x = f`). We perform this transformation before running the C and Wasm extraction pipeline. This is necessary due to a bug in CertiCoq.