### PR TITLE
Update rust setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           opam exec -- make -j${{ env.JOBS }}
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.85.0
 


### PR DESCRIPTION
We switch to using `dtolnay/rust-toolchain` for configuring Rust in CI.
This is necessary since the old setup uses features that are deprecated and set to be removed.