### PR TITLE
Agda Benchmarks

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -53,3 +53,6 @@ bench/targets/lean/build/
 ackermann_*
 nqueens_*
 quicksort_*
+
+# Generated Agda files
+*.agdai

--- a/benchmarks/agda/BinaryTrees.agda
+++ b/benchmarks/agda/BinaryTrees.agda
@@ -1,0 +1,61 @@
+{-
+  Binary Trees Benchmark
+  From the Computer Language Benchmarks Game
+  Allocate and deallocate many binary trees
+-}
+
+module BinaryTrees where
+
+open import Prelude
+
+data Tree : Set where
+  leaf : Tree
+  node : Tree → Nat → Tree → Tree
+
+treeMake : Nat → Tree
+treeMake 0       = leaf
+treeMake (suc n) = node (treeMake n) 0 (treeMake n)
+
+treeCheck : Tree → Nat
+treeCheck leaf         = 0
+treeCheck (node l _ r) = 1 + treeCheck l + treeCheck r
+
+makeCheck : Nat → Nat
+makeCheck d = treeCheck (treeMake d)
+
+stretchTree : Nat → Nat
+stretchTree maxDepth = makeCheck (suc maxDepth)
+
+calcIterations : Nat → Nat → Nat → Nat
+calcIterations maxDepth depth minDepth = pow2 (maxDepth - depth + minDepth)
+
+runIterations : Nat → Nat → Nat → Nat
+runIterations 0       _     acc = acc
+runIterations (suc n) depth acc =
+  runIterations n depth (acc + makeCheck depth)
+
+runDepthsAux : Nat → Nat → Nat → Nat → List Nat → List Nat
+runDepthsAux zero _ _ _ acc = acc
+runDepthsAux (suc fuel) minDepth currentDepth maxDepth acc
+  with currentDepth < maxDepth
+... | true = 
+      let iterations = calcIterations maxDepth currentDepth minDepth
+          result     = runIterations iterations currentDepth 0
+      in runDepthsAux fuel minDepth (2 + currentDepth) maxDepth (result ∷ acc)
+... | false = acc
+
+runDepths : Nat → Nat → List Nat
+runDepths minDepth maxDepth =
+  runDepthsAux (suc maxDepth) minDepth minDepth maxDepth []
+
+binaryTreesSimple : Nat → Nat
+binaryTreesSimple n =
+  let minDepth  = 4
+      maxDepth  = max (minDepth + 2) n
+      stretch   = stretchTree maxDepth
+      longTree  = treeMake maxDepth
+      longCheck = treeCheck longTree
+  in stretch + longCheck
+
+binaryTreesBench : Nat → Nat
+binaryTreesBench n = binaryTreesSimple n

--- a/benchmarks/agda/Fannkuch.agda
+++ b/benchmarks/agda/Fannkuch.agda
@@ -1,0 +1,106 @@
+{-# OPTIONS --erasure #-}
+{-
+  Fannkuch Redux Benchmark
+  From the Computer Language Benchmarks Game
+  Indexed-access to tiny integer-sequence
+
+  Purely functional implementation using immutable lists
+-}
+
+module Fannkuch where
+
+open import Agda.Primitive
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Maybe
+open import Agda.Builtin.List
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Equality
+open import Prelude
+
+-- Reverse the first n elements of a list, keeping the rest
+
+reversePrefix : Nat → List Nat → List Nat
+reversePrefix n l = aux n l []
+  where
+    aux : Nat → List Nat → List Nat → List Nat
+    aux 0       xs       acc = acc ++ xs
+    aux (suc n) []       acc = acc
+    aux (suc n) (x ∷ xs) acc = aux n xs (x ∷ acc)
+
+
+private
+  @0 _ : reversePrefix 3 (1 ∷ 2 ∷ 3 ∷ 4 ∷ 5 ∷ []) ≡ 3 ∷ 2 ∷ 1 ∷ 4 ∷ 5 ∷ []
+  _ = refl
+
+-- One flip operation: reverse prefix of length = first element + 1
+flip : List Nat → List Nat
+flip []           = []
+flip perm@(x ∷ _) = reversePrefix (suc x) perm
+
+{-# TERMINATING  #-}
+-- Count flips until first element is 0
+countFlips : List Nat → Nat
+countFlips = aux 0
+  where
+    aux : Nat → List Nat → Nat
+    aux count []      = count
+    aux count (0 ∷ _) = count
+    aux count perm    = aux (suc count) (flip perm)
+
+-- Rotate first n elements: [a, b, c, d, ...] -> [b, c, d, a, ...]
+rotatePrefix : List Nat → Nat → List Nat
+rotatePrefix [] n = []
+rotatePrefix xs 0 = xs
+rotatePrefix xs 1 = xs
+rotatePrefix (x ∷ xs) (suc n) =
+  let (rest , suffix) = splitAt n xs
+  in rest ++ [ x ] ++ suffix
+
+-- Find the index i where count[i] < i
+findI : List Nat → Maybe Nat
+findI = findIndex (λ i x → x < i)
+
+-- Reset counts from 0 to i-1 to 0
+resetCounts : List Nat → Nat → List Nat
+resetCounts []       _       = []
+resetCounts xs       zero    = xs
+resetCounts (x ∷ xs) (suc i) = 0 ∷ resetCounts xs i
+
+-- Generate next permutation using Heap's algorithm variant
+nextPerm : List Nat → List Nat → Maybe (List Nat × List Nat)
+nextPerm perm counts with findI counts
+... | nothing = nothing
+... | just i  =
+  let perm'    = rotatePrefix perm (suc i)
+      counts'  = updateAt suc counts i
+      counts'' = resetCounts counts' i
+  in just (perm' , counts'')
+
+{-# TERMINATING #-}
+fannkuchLoop : List Nat → List Nat → Nat → Nat
+fannkuchLoop perm counts maxFlips =
+  let flips     = countFlips perm
+      maxFlips' = max maxFlips flips
+  in case nextPerm perm counts of λ where
+    nothing → maxFlips'
+    (just (perm' , counts')) → fannkuchLoop perm' counts' maxFlips'
+
+fannkuch : Nat → Nat
+fannkuch n =
+  let perm   = range n
+      counts = replicate n 0
+  in fannkuchLoop perm counts 0
+
+fannkuchBench : Nat → Nat
+fannkuchBench n = fannkuch n
+
+{-
+private
+  -- sanity check implementation
+  _ : fannkuch 7 ≡ 16
+  _ = refl
+  _ : fannkuch 8 ≡ 22
+  _ = refl
+  _ : fannkuch 9 ≡ 30
+  _ = refl
+-- -}

--- a/benchmarks/agda/Haskell.agda
+++ b/benchmarks/agda/Haskell.agda
@@ -1,0 +1,43 @@
+-- Boilerplate for Haskell compilation
+
+module Haskell where
+
+{-# FOREIGN GHC {-# LANGUAGE LambdaCase #-} #-}
+
+open import Agda.Builtin.IO         public
+open import Agda.Builtin.String
+  renaming (primShowNat to showNat) public
+
+open import Prelude
+
+{-# FOREIGN GHC import System.Environment (getArgs) #-}
+{-# FOREIGN GHC import qualified Data.Text.IO as Text #-}
+{-# FOREIGN GHC import Data.Functor ((<&>)) #-}
+
+postulate
+  _>>=_    : IO A → (A → IO B) → IO B
+  _>>_     : IO A → IO B → IO B
+  return   : A → IO A
+  putStrLn : String → IO ⊤
+  getInput : Nat → IO Nat
+{-# COMPILE GHC _>>=_    = \_ _ _ _ -> (>>=)  #-}
+{-# COMPILE GHC _>>_     = \_ _ _ _ -> (>>)  #-}
+{-# COMPILE GHC return   = \_ _ -> return #-}
+{-# COMPILE GHC putStrLn = Text.putStrLn #-}
+{-# COMPILE GHC getInput = getInput #-}
+
+infixr -1 _$_
+_$_ : (A → B) → A → B
+f $ x = f x
+{-# INLINE _$_ #-}
+
+{-# FOREIGN GHC
+
+  -- | Try to read an integer from std input args
+  -- otherwise use default value
+  getInput :: Integer -> IO Integer
+  getInput n = getArgs <&> \case
+    [s] -> read s
+    _   -> n
+
+#-}

--- a/benchmarks/agda/MainBinaryTrees.agda
+++ b/benchmarks/agda/MainBinaryTrees.agda
@@ -1,0 +1,11 @@
+module MainBinaryTrees where
+
+open import Prelude
+open import Haskell
+open import BinaryTrees
+
+main : IO ⊤
+main = do
+  n ← getInput 10
+  -- log the result (i.e. force evaluation)
+  putStrLn $ showNat $ binaryTreesBench n

--- a/benchmarks/agda/MainFannkuch.agda
+++ b/benchmarks/agda/MainFannkuch.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --erasure #-}
+module MainFannkuch where
+
+open import Prelude
+open import Haskell
+open import Fannkuch
+
+main : IO ⊤
+main = do
+  n ← getInput 10
+  -- log the result (i.e. force evaluation)
+  putStrLn $ showNat $ fannkuchBench n

--- a/benchmarks/agda/Makefile
+++ b/benchmarks/agda/Makefile
@@ -1,0 +1,61 @@
+# Agda Benchmarks Makefile
+# 
+# Compiles idiomatic Agda implementations to Haskell via MAlonzo,
+# then to native code using GHC
+
+TARGETS := BinaryTrees Fannkuch
+.PHONY: all clean check $(TARGETS) help
+
+AGDA := agda
+GHC := ghc
+GHC_RTS_OPTS := -s
+GHC_FLAGS    := -package=text -O2 -rtsopts
+AGDA_GHC_FLAGS := $(foreach f,$(GHC_FLAGS),--ghc-flag=$(f))
+AGDA_GHC_FLAGS += --ghc-flag=-with-rtsopts="$(GHC_RTS_OPTS)"
+
+# Outputs
+BINARIES := $(addprefix bin/, $(TARGETS))
+
+all: check $(TARGETS)
+
+help:
+	@echo "Agda Benchmarks Makefile"
+	@echo ""
+	@echo "Targets:"
+	@echo "  make all              - Build all benchmarks"
+	@echo "  make check            - Type-check all Agda files"
+	@echo "  make BinaryTrees      - Build BinaryTrees benchmark"
+	@echo "  make Fannkuch         - Build Fannkuch benchmark"
+	@echo "  make clean            - Clean build artifacts"
+
+# Type-check all Agda files
+check:
+	@echo "=== Type-checking Agda files ==="
+	$(AGDA) BinaryTrees.agda
+	$(AGDA) Fannkuch.agda
+	@echo "✓ All files type-checked successfully"
+
+# Create output directory
+bin:
+	mkdir -p bin
+
+$(TARGETS): %: bin/%
+
+# Compile Main program(s)
+bin/%: Main%.agda bin %.agda Haskell.agda
+	@echo "=== Compiling $* ==="
+	mkdir -p _build$*
+	$(AGDA) --ghc --compile-dir=_build$* $(AGDA_GHC_FLAGS) $<
+	@if [ -f _build$*/Main$* ]; then \
+		cp _build$*/Main$* $@; \
+		echo "✓ $* compiled to $@"; \
+	else \
+		echo "✗ Compilation failed"; \
+		exit 1; \
+	fi
+
+# Clean build artifacts
+clean:
+	rm -rf bin/
+	rm -rf _build*
+	rm -rf MAlonzo *~

--- a/benchmarks/agda/Prelude.agda
+++ b/benchmarks/agda/Prelude.agda
@@ -1,0 +1,117 @@
+module Prelude where
+
+open import Agda.Builtin.Bool     public
+open import Agda.Builtin.Equality public
+open import Agda.Builtin.List     public
+open import Agda.Builtin.Maybe    public
+open import Agda.Builtin.Nat      public
+open import Agda.Builtin.String   public
+open import Agda.Builtin.Unit     public
+open import Agda.Primitive        public
+
+variable
+  a b : Level
+  A   : Set a
+  B   : Set b
+
+infix -1 if_then_else_
+if_then_else_ : Bool → A → A → A
+if true  then x else y = x
+if false then x else y = y
+
+double : Nat → Nat
+double zero    = zero
+double (suc n) = suc (suc (double n))
+
+pow2 : Nat → Nat
+pow2 0       = 1
+pow2 (suc n) = double (pow2 n)
+
+max : Nat → Nat → Nat
+max x y = if x < y then y else x
+
+infixr 6 _++_
+_++_ : List A → List A → List A
+[]       ++ ys = ys
+(x ∷ xs) ++ ys = x ∷ (xs ++ ys)
+
+pattern [_] x = _∷_ x []
+
+foldr : (A → B → B) → B → List A → B
+foldr c n []       = n
+foldr c n (x ∷ xs) = c x (foldr c n xs)
+
+foldl : (A → B → A) → A → List B → A
+foldl c n []       = n
+foldl c n (x ∷ xs) = foldl c (c n x) xs
+
+rev : List A → List A
+rev = foldl (λ xs x → x ∷ xs) []
+
+length : List A → Nat
+length = foldr (λ _ → suc) 0
+
+-- mod n m ≡ n % (suc m)
+mod : Nat → Nat → Nat
+mod n m = mod-helper 0 m n m
+
+infixl 4 _,_
+record _×_ (A : Set a) (B : Set b) : Set (a ⊔ b) where
+  constructor _,_
+  field
+    fst : A
+    snd : B
+open _×_ public
+
+splitAt : Nat → List A → (List A × List A)
+splitAt zero    xs       = ([] , xs)
+splitAt (suc n) []       = ([] , [])
+splitAt (suc n) (x ∷ xs) with splitAt n xs
+... | (ys , zs) = (x ∷ ys , zs)
+
+setAt : List A → Nat → A → List A
+setAt [] k y = []
+setAt (x ∷ xs) zero    y = y ∷ xs
+setAt (x ∷ xs) (suc k) y = x ∷ setAt xs k y
+
+getAt : List Nat → Nat → Nat
+getAt [] k = 0
+getAt (x ∷ xs) zero = x
+getAt (x ∷ xs) (suc k) = getAt xs k
+
+updateAt : (A → A) → List A → Nat → List A
+updateAt f [] k = []
+updateAt f (x ∷ xs) zero    = f x ∷ xs
+updateAt f (x ∷ xs) (suc k) = x   ∷ updateAt f xs k
+
+-- find first index k such that P k xs[k] is true
+findIndex : (P : Nat → A → Bool) → List A → Maybe Nat
+findIndex {A = A} P = aux 0
+  where aux : Nat → List A → Maybe Nat
+        aux k []       = nothing
+        aux k (x ∷ xs) =
+          if P k x then just k
+                   else aux (suc k) xs
+
+tail : List A → List A
+tail [] = []
+tail (_ ∷ xs) = xs
+
+case_of_ : A → (A → B) → B
+case x of f = f x
+
+-- invrange n = [(n - 1) .. 0]
+invrange range : Nat → List Nat
+invrange 0       = []
+invrange (suc n) = n ∷ invrange n
+
+-- range n = [0 .. (n - 1)]
+range n = rev (invrange n)
+
+replicate : Nat → A → List A
+replicate zero    x = []
+replicate (suc n) x = x ∷ replicate n x
+
+mapMaybe : (f : A → A) → Maybe A → Maybe A
+mapMaybe f nothing = nothing
+mapMaybe f (just x) = just (f x)

--- a/benchmarks/agda/Prelude.agda
+++ b/benchmarks/agda/Prelude.agda
@@ -84,14 +84,15 @@ updateAt f [] k = []
 updateAt f (x ∷ xs) zero    = f x ∷ xs
 updateAt f (x ∷ xs) (suc k) = x   ∷ updateAt f xs k
 
+findIndexAux : (P : Nat → A → Bool) → Nat → List A → Maybe Nat
+findIndexAux P k []       = nothing
+findIndexAux P k (x ∷ xs) =
+  if P k x then just k
+           else findIndexAux P (suc k) xs
+
 -- find first index k such that P k xs[k] is true
 findIndex : (P : Nat → A → Bool) → List A → Maybe Nat
-findIndex {A = A} P = aux 0
-  where aux : Nat → List A → Maybe Nat
-        aux k []       = nothing
-        aux k (x ∷ xs) =
-          if P k x then just k
-                   else aux (suc k) xs
+findIndex {A = A} P = findIndexAux P 0
 
 tail : List A → List A
 tail [] = []

--- a/benchmarks/agda/README.md
+++ b/benchmarks/agda/README.md
@@ -1,0 +1,27 @@
+# Agda Benchmarks
+
+This folder contains idiomatic Agda implementations of the following Benchmarks:
+
+1. **BinaryTrees.agda** - Allocates and deallocates many binary trees, computing checksums.
+2. **Fannkuch.agda** - Indexed-access to tiny integer-sequences via permutations and flips.
+
+The implementation is based on the one for Lean, in this very same repo.
+
+---
+
+
+```bash
+$ make help
+Agda Benchmarks Makefile
+
+Targets:
+  make all              - Build all benchmarks
+  make check            - Type-check all Agda files
+  make BinaryTrees      - Build BinaryTrees benchmark
+  make Fannkuch         - Build Fannkuch benchmark
+  make clean            - Clean build artifacts
+```
+
+Once `make all` is run, `bin/` contains both `BinaryTrees` and `Fannkuch` executables.
+Both may take an integer as argument, and have been compiled with the `-s` RTS option,
+so they display timing information when executed.


### PR DESCRIPTION
Based on #43, adding an Agda implementation for BinaryTrees and Fannkuch.
They are based on the Lean implementation, though I just noticed the Lean Fannkuch benchmarks is marked as failing in the report?

Anyways, they compile fine using MAlonzo.
I can add compilation to LBox and/or include the generated `.ast` files if needed.

Feel free to use this any way you see fit.