### PR TITLE
Enable unboxing by default for the Rust backend

### DIFF
--- a/theories/backends/RustBackend.v
+++ b/theories/backends/RustBackend.v
@@ -28,7 +28,7 @@ Definition rust_phases := {|
   implement_lazy_c := Compatible false;
   cofix_to_laxy_c  := Compatible false;
   betared_c        := Compatible false;
-  unboxing_c       := Compatible false;
+  unboxing_c       := Compatible true;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
 |}.


### PR DESCRIPTION
`rust_phases` had `unboxing_c := Compatible false`, unlike the OCaml and CakeML backends which enable it. This one-line change turns it on, so the Rust backend also unboxes single-constructor single-field types (e.g. proof-carrying wrappers) instead of emitting the indirection.

Scope: a single phase-config default in `theories/backends/RustBackend.v`; no new definitions. `RustBackend.v` compiles with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)