### PR TITLE
Merge Lean 4 backend with native/mixed Rust backends and HM bridge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         ocaml_version: ["4.14.2"] #, "5.3.0"]
     steps:
       - name: Checkout branch ${{ github.ref_name }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - run: sudo apt-get update
       - name: Restore opam cache
@@ -98,7 +98,7 @@ jobs:
           cabal-version: ${{env.CABAL_VERSION}}
 
       - name: Checkout agda2lambox
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: 4ever2/agda2lambox
           ref: 20120b78af01b7bec1c8d46ba8dceef140d65fb6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: sudo apt-get update
       - name: Restore opam cache
         id: opam-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: "~/.opam"
           key: opam-${{matrix.ocaml_version}}-${{hashFiles('.github/rocq-peregrine.opam.locked')}}
@@ -110,7 +110,7 @@ jobs:
           cabal configure --disable-documentation && \
           cabal build all --dry-run
       - name: Restore cached Haskell dependencies
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         id: haskell-cache
         env:
           key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}
@@ -123,7 +123,7 @@ jobs:
         if: steps.haskell-cache.outputs.cache-hit != 'true'
         run: cd agda && cabal build all --only-dependencies
       - name: Save cached dependencies
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         if: steps.haskell-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.haskell-setup.outputs.cabal-store }}

--- a/.github/workflows/lint-opam.yml
+++ b/.github/workflows/lint-opam.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up opam
         uses: ocaml/setup-ocaml@v3
         with:

--- a/.github/workflows/nix-action-9.1.yml
+++ b/.github/workflows/nix-action-9.1.yml
@@ -11,7 +11,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -25,7 +25,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -84,7 +84,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -98,7 +98,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -169,7 +169,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -183,7 +183,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -253,7 +253,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -267,7 +267,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -325,7 +325,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -339,7 +339,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -392,7 +392,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -406,7 +406,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -452,7 +452,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -466,7 +466,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -529,7 +529,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -543,7 +543,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -610,7 +610,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -624,7 +624,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -690,7 +690,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -704,7 +704,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -766,7 +766,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -780,7 +780,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -843,7 +843,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -857,7 +857,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -924,7 +924,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -938,7 +938,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -1004,7 +1004,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -1018,7 +1018,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -1079,7 +1079,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -1093,7 +1093,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -1149,7 +1149,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -1163,7 +1163,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}
@@ -1206,7 +1206,7 @@ jobs:
         github.sha }}\" >> $GITHUB_ENV\nelse\n  echo \"target_commit=${{ github.event.pull_request.head.sha
         }}\" >> $GITHUB_ENV\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.target_commit }}
@@ -1220,7 +1220,7 @@ jobs:
         }}\" >> $GITHUB_ENV\n  else\n    echo \"tested_commit=$merge_commit\" >> $GITHUB_ENV\n\
         \  fi\nfi\n"
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         ref: ${{ env.tested_commit }}

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ test/**/*.anf
 *.h
 *.mlf
 *.cml
+.claude/

--- a/_CoqProject
+++ b/_CoqProject
@@ -16,8 +16,15 @@ theories/erasure/Erasure.v
 theories/erasure/ErasureTyped.v
 theories/erasure/Transforms.v
 theories/erasure/EImplementLazyForce.v
+theories/erasure/EInstanceSpecialize.v
+theories/erasure/EHindleyMilner.v
+theories/erasure/EHMNumericSigs.v
 
 theories/backends/RustBackend.v
+theories/backends/RustGMPRemaps.v
+theories/backends/RustNativeRemaps.v
+theories/backends/RustMixedRemaps.v
+theories/backends/RustMixedCoherence.v
 theories/backends/ElmBackend.v
 theories/backends/OCamlBackend.v
 theories/backends/CakeMLBackend.v

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -14,17 +14,19 @@ let mk_copts verbose debug output_file attrs = {
 }
 
 type erasure_opts = {
-  betared        : bool option;
-  unboxing       : bool option;
-  dearg_ctors    : bool option;
-  dearg_consts   : bool option;
+  betared             : bool option;
+  unboxing            : bool option;
+  dearg_ctors         : bool option;
+  dearg_consts        : bool option;
+  specialize_instances : bool option;
 }
 
-let mk_erasure_opts betared unboxing dearg_ctors dearg_consts = {
+let mk_erasure_opts betared unboxing dearg_ctors dearg_consts specialize_instances = {
   betared;
   unboxing;
   dearg_ctors;
   dearg_consts;
+  specialize_instances;
 }
 
 type certirocq_opts = {

--- a/bin/compile.ml
+++ b/bin/compile.ml
@@ -215,10 +215,22 @@ let compile_rust_native opts eopts f_prog =
 let compile_rust_mixed opts eopts f_prog =
   (* Path C: mixed representation.  Default path A (rug::Integer), with a
      directive-selected partition of ops compiled in path B (native i64) behind
-     A<->B coercions. *)
+     A<->B coercions.  Partition 1 ([b_partition]): all nine core nat ops. *)
   let b_opts = ConfigUtils.Rust' RustMixedRemaps.mixed_rust_config' in
   compile_backend
     ~const_remaps:RustMixedRemaps.mixed_const_remaps
+    ~ind_remaps:RustMixedRemaps.mixed_ind_remaps
+    b_opts opts eopts f_prog
+
+let compile_rust_mixed2 opts eopts f_prog =
+  (* Path C, alternative partition ([narrow_b_partition]): only div/mod/pow
+     run natively; add/mul/sub/eqb/leb/ltb stay arbitrary-precision.  Same
+     mixed backend machinery (coercions, preamble, ind_remaps) as [rustm] --
+     only WHICH ops are in the B partition differs, demonstrating that
+     correctness does not depend on the partition chosen. *)
+  let b_opts = ConfigUtils.Rust' RustMixedRemaps.mixed_rust_config' in
+  compile_backend
+    ~const_remaps:RustMixedRemaps.mixed_const_remaps2
     ~ind_remaps:RustMixedRemaps.mixed_ind_remaps
     b_opts opts eopts f_prog
 

--- a/bin/compile.ml
+++ b/bin/compile.ml
@@ -197,6 +197,17 @@ let compile_backend ?(const_remaps=[]) ?(ind_remaps=[]) backend_opts opts eopts 
   let config = mk_config ~const_remaps ~ind_remaps backend_opts eopts in
   compile_aux opts f_prog prog (Datatypes.Coq_inr config)
 
+let compile_rust_unremapped opts eopts f_prog =
+  (* No numeric remapping at all: nat/positive/N/Z are extracted as the
+     inductives they are, so [nat] becomes an arena-allocated successor chain.
+     Arithmetic is asymptotically the same as what the C, OCaml, Wasm, CakeML
+     and Lean backends run, which is precisely what makes this the column that
+     may be compared with them.  [rust] (GMP) and [rustb] (native i64) both
+     replace the *program*, not just its codegen, so their times answer a
+     different question. *)
+  let b_opts = ConfigUtils.Rust' ConfigUtils.empty_rust_config' in
+  compile_backend b_opts opts eopts f_prog
+
 let compile_rust opts eopts f_prog =
   (* Wire in the GMP numeric backend: the [rug::Integer] preamble plus the
      nat/positive/N/Z arithmetic remaps (config-path analogue of the plugin's

--- a/bin/compile.ml
+++ b/bin/compile.ml
@@ -4,6 +4,9 @@ open Peregrine.Caml_bytestring
 module Datatypes = Peregrine.Datatypes
 module Config = Peregrine.Config1
 module ConfigUtils = Peregrine.ConfigUtils
+module RustGMPRemaps = Peregrine.RustGMPRemaps
+module RustNativeRemaps = Peregrine.RustNativeRemaps
+module RustMixedRemaps = Peregrine.RustMixedRemaps
 module Pipeline = Peregrine.Pipeline2
 module ResultMonad = Peregrine.ResultMonad
 module Cps = Peregrine.Cps
@@ -121,14 +124,15 @@ let mk_erasure_config eopts = {
   ConfigUtils.unboxing'       = eopts.unboxing;
   ConfigUtils.dearg_ctors'    = eopts.dearg_ctors;
   ConfigUtils.dearg_consts'   = eopts.dearg_consts;
+  ConfigUtils.specialize_instances' = eopts.specialize_instances;
 }
 
-let mk_config b eopts = {
+let mk_config ?(const_remaps=[]) ?(ind_remaps=[]) b eopts = {
   ConfigUtils.backend_opts' = b;
   ConfigUtils.erasure_opts' = Some (mk_erasure_config eopts);
   ConfigUtils.inlinings_opts' = [];
-  ConfigUtils.const_remappings_opts' = [];
-  ConfigUtils.ind_remappings_opts' = [];
+  ConfigUtils.const_remappings_opts' = const_remaps;
+  ConfigUtils.ind_remappings_opts' = ind_remaps;
   ConfigUtils.cstr_reorders_opts' = [];
   ConfigUtils.custom_attributes_opts' = []
 }
@@ -182,14 +186,41 @@ let compile opts f_prog f_config =
   let config = f_config |> read_file |> bytestring_of_caml_string in
   compile_aux opts f_prog prog (Datatypes.Coq_inl config)
 
-let compile_backend backend_opts opts eopts f_prog =
+let compile_backend ?(const_remaps=[]) ?(ind_remaps=[]) backend_opts opts eopts f_prog =
   let prog = f_prog |> read_file |> bytestring_of_caml_string in
-  let config = mk_config backend_opts eopts in
+  let config = mk_config ~const_remaps ~ind_remaps backend_opts eopts in
   compile_aux opts f_prog prog (Datatypes.Coq_inr config)
 
 let compile_rust opts eopts f_prog =
-  let b_opts = ConfigUtils.Rust' ConfigUtils.empty_rust_config' in
-  compile_backend b_opts opts eopts f_prog
+  (* Wire in the GMP numeric backend: the [rug::Integer] preamble plus the
+     nat/positive/N/Z arithmetic remaps (config-path analogue of the plugin's
+     ExtrRustGMP.v).  Without these the Rust backend lowers nat/N/Z to unary
+     Peano / binary-inductive towers, giving catastrophic arithmetic. *)
+  let b_opts = ConfigUtils.Rust' RustGMPRemaps.gmp_rust_config' in
+  compile_backend
+    ~const_remaps:RustGMPRemaps.gmp_const_remaps
+    ~ind_remaps:RustGMPRemaps.gmp_ind_remaps
+    b_opts opts eopts f_prog
+
+let compile_rust_native opts eopts f_prog =
+  (* Path B: the native-i64 numeric representation (no arena, no Box::leak).
+     Fast for values within i64 range; the mixed backend combines it with the
+     arbitrary-precision path A via coercions. *)
+  let b_opts = ConfigUtils.Rust' RustNativeRemaps.native_rust_config' in
+  compile_backend
+    ~const_remaps:RustNativeRemaps.native_const_remaps
+    ~ind_remaps:RustNativeRemaps.native_ind_remaps
+    b_opts opts eopts f_prog
+
+let compile_rust_mixed opts eopts f_prog =
+  (* Path C: mixed representation.  Default path A (rug::Integer), with a
+     directive-selected partition of ops compiled in path B (native i64) behind
+     A<->B coercions. *)
+  let b_opts = ConfigUtils.Rust' RustMixedRemaps.mixed_rust_config' in
+  compile_backend
+    ~const_remaps:RustMixedRemaps.mixed_const_remaps
+    ~ind_remaps:RustMixedRemaps.mixed_ind_remaps
+    b_opts opts eopts f_prog
 
 let compile_elm opts eopts f_prog =
   let b_opts = ConfigUtils.Elm' ConfigUtils.empty_elm_config' in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -181,7 +181,7 @@ let rustm_cmd =
     Arg.(required & pos 0 (some file) None & info []
            ~docv:"FILE" ~doc)
   in
-  let doc = "Compile lambda box program to Rust (path C: mixed A/B with coercions)" in
+  let doc = "Compile lambda box program to Rust (path C: mixed A/B with coercions, partition 1: add/mul/sub/div/mod/pow/eqb/leb/ltb in B)" in
   let man = [
     `S Manpage.s_description;
     `P "";
@@ -189,6 +189,21 @@ let rustm_cmd =
   in
   let info = Cmd.info "rustm" ~doc ~sdocs ~man in
   Cmd.v info Term.(const compile_rust_mixed $ copts_t $ erasure_opts_t $ program_file)
+
+let rustm2_cmd =
+  let program_file =
+    let doc = "lambda box program" in
+    Arg.(required & pos 0 (some file) None & info []
+           ~docv:"FILE" ~doc)
+  in
+  let doc = "Compile lambda box program to Rust (path C: mixed A/B with coercions, partition 2: only div/mod/pow in B)" in
+  let man = [
+    `S Manpage.s_description;
+    `P "";
+    `Blocks help_secs; ]
+  in
+  let info = Cmd.info "rustm2" ~doc ~sdocs ~man in
+  Cmd.v info Term.(const compile_rust_mixed2 $ copts_t $ erasure_opts_t $ program_file)
 
 let elm_cmd =
   let program_file =
@@ -332,6 +347,6 @@ let main_cmd =
   let man = help_secs in
   let info = Cmd.info "peregrine" ~version ~doc ~sdocs ~man ~exits in
   let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ copts_t)) in
-  Cmd.group info ~default [compile_cmd; rust_cmd; rustb_cmd; rustm_cmd; elm_cmd; ocaml_cmd; cakeml_cmd; c_cmd; wasm_cmd; eval_cmd; ast_cmd; validate_cmd; help_cmd]
+  Cmd.group info ~default [compile_cmd; rust_cmd; rustb_cmd; rustm_cmd; rustm2_cmd; elm_cmd; ocaml_cmd; cakeml_cmd; c_cmd; wasm_cmd; eval_cmd; ast_cmd; validate_cmd; help_cmd]
 
 let () = exit (Cmd.eval main_cmd)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -71,7 +71,11 @@ let erasure_opts_t =
     let doc = "Dearg constants." in
     Arg.(value & opt (some bool) None & info ["dearg-consts"] ~doc)
   in
-  Term.(const mk_erasure_opts $ betared_arg $ unbox_arg $ dearg_ctors_arg $ dearg_consts_arg)
+  let specialize_instances_arg =
+    let doc = "Specialize functions on statically-known typeclass/dictionary arguments." in
+    Arg.(value & opt (some bool) None & info ["specialize-instances"] ~doc)
+  in
+  Term.(const mk_erasure_opts $ betared_arg $ unbox_arg $ dearg_ctors_arg $ dearg_consts_arg $ specialize_instances_arg)
 
 
 let sdocs = Manpage.s_common_options
@@ -155,6 +159,36 @@ let rust_cmd =
   in
   let info = Cmd.info "rust" ~doc ~sdocs ~man in
   Cmd.v info Term.(const compile_rust $ copts_t $ erasure_opts_t $ program_file)
+
+let rustb_cmd =
+  let program_file =
+    let doc = "lambda box program" in
+    Arg.(required & pos 0 (some file) None & info []
+           ~docv:"FILE" ~doc)
+  in
+  let doc = "Compile lambda box program to Rust (path B: native i64 numerics)" in
+  let man = [
+    `S Manpage.s_description;
+    `P "";
+    `Blocks help_secs; ]
+  in
+  let info = Cmd.info "rustb" ~doc ~sdocs ~man in
+  Cmd.v info Term.(const compile_rust_native $ copts_t $ erasure_opts_t $ program_file)
+
+let rustm_cmd =
+  let program_file =
+    let doc = "lambda box program" in
+    Arg.(required & pos 0 (some file) None & info []
+           ~docv:"FILE" ~doc)
+  in
+  let doc = "Compile lambda box program to Rust (path C: mixed A/B with coercions)" in
+  let man = [
+    `S Manpage.s_description;
+    `P "";
+    `Blocks help_secs; ]
+  in
+  let info = Cmd.info "rustm" ~doc ~sdocs ~man in
+  Cmd.v info Term.(const compile_rust_mixed $ copts_t $ erasure_opts_t $ program_file)
 
 let elm_cmd =
   let program_file =
@@ -298,6 +332,6 @@ let main_cmd =
   let man = help_secs in
   let info = Cmd.info "peregrine" ~version ~doc ~sdocs ~man ~exits in
   let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ copts_t)) in
-  Cmd.group info ~default [compile_cmd; rust_cmd; elm_cmd; ocaml_cmd; cakeml_cmd; c_cmd; wasm_cmd; eval_cmd; ast_cmd; validate_cmd; help_cmd]
+  Cmd.group info ~default [compile_cmd; rust_cmd; rustb_cmd; rustm_cmd; elm_cmd; ocaml_cmd; cakeml_cmd; c_cmd; wasm_cmd; eval_cmd; ast_cmd; validate_cmd; help_cmd]
 
 let () = exit (Cmd.eval main_cmd)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -160,6 +160,21 @@ let rust_cmd =
   let info = Cmd.info "rust" ~doc ~sdocs ~man in
   Cmd.v info Term.(const compile_rust $ copts_t $ erasure_opts_t $ program_file)
 
+let rustu_cmd =
+  let program_file =
+    let doc = "lambda box program" in
+    Arg.(required & pos 0 (some file) None & info []
+           ~docv:"FILE" ~doc)
+  in
+  let doc = "Compile lambda box program to Rust (no numeric remapping)" in
+  let man = [
+    `S Manpage.s_description;
+    `P "";
+    `Blocks help_secs; ]
+  in
+  let info = Cmd.info "rustu" ~doc ~sdocs ~man in
+  Cmd.v info Term.(const compile_rust_unremapped $ copts_t $ erasure_opts_t $ program_file)
+
 let rustb_cmd =
   let program_file =
     let doc = "lambda box program" in
@@ -362,6 +377,6 @@ let main_cmd =
   let man = help_secs in
   let info = Cmd.info "peregrine" ~version ~doc ~sdocs ~man ~exits in
   let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ copts_t)) in
-  Cmd.group info ~default [compile_cmd; rust_cmd; rustb_cmd; rustm_cmd; rustm2_cmd; elm_cmd; ocaml_cmd; cakeml_cmd; lean_cmd; c_cmd; wasm_cmd; eval_cmd; ast_cmd; validate_cmd; help_cmd]
+  Cmd.group info ~default [compile_cmd; rust_cmd; rustu_cmd; rustb_cmd; rustm_cmd; rustm2_cmd; elm_cmd; ocaml_cmd; cakeml_cmd; lean_cmd; c_cmd; wasm_cmd; eval_cmd; ast_cmd; validate_cmd; help_cmd]
 
 let () = exit (Cmd.eval main_cmd)

--- a/test/rocq/theories/Classy.v
+++ b/test/rocq/theories/Classy.v
@@ -1,0 +1,18 @@
+(* Typeclass-heavy example: dictionaries dragged through operations,
+   mirroring Lean's HAdd/OfNat plumbing for [1 + 1].
+   Uses non-recursive operations to keep the whole box pipeline wellformed. *)
+
+Definition op1 (x y : nat) : nat := x.
+Definition op2 (x y : nat) : nat := y.
+
+Class Add (A : Type) := { add : A -> A -> A }.
+#[export] Instance addNat : Add nat := { add := op1 }.
+
+Class Mul (A : Type) := { mul : A -> A -> A }.
+#[export] Instance mulNat : Mul nat := { mul := op2 }.
+
+(* A polymorphic function taking two dictionaries. *)
+Definition poly {A} `{Add A} `{Mul A} (x y z : A) : A :=
+  add (mul x y) z.
+
+Definition test : nat := poly 2 3 4.

--- a/test/rocq/theories/ClassyExtract.v
+++ b/test/rocq/theories/ClassyExtract.v
@@ -1,0 +1,4 @@
+From Peregrine.Plugin Require Import Loader.
+From Peregrine.Tests Require Classy.
+
+Peregrine Extract "extraction/Classy.ast" Classy.test.

--- a/test/src/tests.ts
+++ b/test/src/tests.ts
@@ -50,14 +50,14 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/Exports.ast",
-            main: "Exports_test",
+            main: "Exports_main",
             output_type: SimpleType.Other,
             expected_output: ["", ""],
             parameters: []
         },
         {
             src: "agda/Hello.ast",
-            main: "Hello_test",
+            main: "Hello_hello",
             output_type: { type: "list", a_t: SimpleType.Nat },
             expected_output: [
                 "(cons (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) (cons (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) (cons (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) (cons (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) (cons (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) (cons (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O))))))))))))))))))))))))))))))))) nil))))))",
@@ -68,7 +68,7 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/Imports.ast",
-            main: "Imports_test",
+            main: "Imports_test2",
             output_type: { type: "list", a_t: SimpleType.Nat },
             expected_output: [
                 "(cons (S (S (S (S (S (S O)))))) nil)",
@@ -79,21 +79,21 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/Input.ast",
-            main: "Input_test",
+            main: "Input_main",
             output_type: SimpleType.Other,
             expected_output: ["", ""],
             parameters: []
         },
         {
             src: "agda/Irr.ast",
-            main: "Irr_test",
+            main: "Irr_xs",
             output_type: SimpleType.Other,
             expected_output: undefined,
             parameters: []
         },
         {
             src: "agda/K.ast",
-            main: "K_test",
+            main: "K_K",
             output_type: SimpleType.Other,
             expected_output: undefined,
             parameters: []
@@ -117,7 +117,7 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/Map.ast",
-            main: "Map_test",
+            main: "Map_ys",
             output_type: { type: "list", a_t: SimpleType.Nat },
             expected_output: [
                 "(cons (S (S O)) (cons (S (S (S (S (S (S O)))))) (cons (S (S (S (S (S (S (S (S (S (S O)))))))))) nil)))",
@@ -135,7 +135,7 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/Nat.ast",
-            main: "Nat_test",
+            main: "Nat_thing",
             output_type: SimpleType.Nat,
             expected_output: ["(S (S (S O)))", "", ""],
             parameters: []
@@ -156,7 +156,7 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/Proj.ast",
-            main: "Proj_test",
+            main: "Proj_second",
             output_type: SimpleType.Bool,
             expected_output: ["false", "", ""],
             parameters: []
@@ -170,7 +170,7 @@ var agda_tests: TestCase[] =
         },
         {
             src: "agda/scheme.ast",
-            main: "scheme_test",
+            main: "scheme_demo",
             output_type: SimpleType.Nat,
             expected_output: ["(S (S (S (S (S (S O))))))", ""],
             parameters: []
@@ -205,14 +205,14 @@ var agda_tests: TestCase[] =
             }, */ // No main to test
         {
             src: "agda/Unicode.ast",
-            main: "Unicode_test",
+            main: "Unicode_main",
             output_type: { type: "list", a_t: SimpleType.Nat },
             expected_output: ["(cons (S O) nil)", "", ""],
             parameters: []
         },
         {
             src: "agda/With.ast",
-            main: "With_test",
+            main: "With_ys",
             output_type: { type: "list", a_t: SimpleType.Bool },
             expected_output: ["(cons true nil)", "", ""],
             parameters: []

--- a/theories/Config.v
+++ b/theories/Config.v
@@ -135,6 +135,7 @@ Section GeneralConfig.
       unboxing_c       : phases_config;
       dearg_ctors_c    : phases_config;
       dearg_consts_c   : phases_config;
+      specialize_instances_c : phases_config;
     }.
 
   Record erasure_phases := {
@@ -145,6 +146,9 @@ Section GeneralConfig.
       unboxing       : bool;
       dearg_ctors    : bool;
       dearg_consts   : bool;
+      (* Instance/dictionary specialization (Peregrine-local unsafe pass,
+         see erasure/EInstanceSpecialize.v). *)
+      specialize_instances : bool;
     }.
 
   Record config := {

--- a/theories/ConfigUtils.v
+++ b/theories/ConfigUtils.v
@@ -255,6 +255,7 @@ Section GeneralConfigOptional.
     unboxing'       : option bool;
     dearg_ctors'    : option bool;
     dearg_consts'   : option bool;
+    specialize_instances' : option bool;
   }.
   Definition empty_erasure_phases' : erasure_phases' := {|
     implement_box'  := None;
@@ -264,6 +265,7 @@ Section GeneralConfigOptional.
     unboxing'       := None;
     dearg_ctors'    := None;
     dearg_consts'   := None;
+    specialize_instances' := None;
   |}.
 
   Definition get_default_phase_opt' (o : erasure_phases_config) (p : erasure_phases_config -> phases_config) : bool :=
@@ -281,6 +283,7 @@ Section GeneralConfigOptional.
     unboxing       := get_default_phase_opt' o unboxing_c;
     dearg_ctors    := get_default_phase_opt' o dearg_ctors_c;
     dearg_consts   := get_default_phase_opt' o dearg_consts_c;
+    specialize_instances := get_default_phase_opt' o specialize_instances_c;
   |}.
 
   Definition enforce_phase' (b' : option bool) (b : bool) (o : phases_config) : bool :=
@@ -302,6 +305,7 @@ Section GeneralConfigOptional.
     unboxing       := enforce_phase' o.(unboxing')       d.(unboxing)       o'.(unboxing_c);
     dearg_ctors    := enforce_phase' o.(dearg_ctors')    d.(dearg_ctors)    o'.(dearg_ctors_c);
     dearg_consts   := enforce_phase' o.(dearg_consts')   d.(dearg_consts)   o'.(dearg_consts_c);
+    specialize_instances := enforce_phase' o.(specialize_instances') d.(specialize_instances) o'.(specialize_instances_c);
   |}.
 
   Definition mk_erasure_phases (b : backend_config') (o : option erasure_phases') : erasure_phases :=

--- a/theories/Extraction.v
+++ b/theories/Extraction.v
@@ -75,7 +75,7 @@ Separate Extraction Pipeline.peregrine_pipeline Pipeline.peregrine_validate
                     ConfigUtils.empty_ocaml_config' ConfigUtils.empty_cakeml_config' ConfigUtils.empty_config'
                     RustGMPRemaps.gmp_const_remaps RustGMPRemaps.gmp_ind_remaps RustGMPRemaps.gmp_rust_config'
                     RustNativeRemaps.native_const_remaps RustNativeRemaps.native_ind_remaps RustNativeRemaps.native_rust_config'
-                    RustMixedRemaps.mixed_const_remaps RustMixedRemaps.mixed_ind_remaps RustMixedRemaps.mixed_rust_config'
+                    RustMixedRemaps.mixed_const_remaps RustMixedRemaps.mixed_const_remaps2 RustMixedRemaps.mixed_ind_remaps RustMixedRemaps.mixed_rust_config'
                     Floats.Float32.to_bits Floats.Float.to_bits
                     Floats.Float32.of_bits Floats.Float.of_bits
                     Csyntax

--- a/theories/Extraction.v
+++ b/theories/Extraction.v
@@ -1,6 +1,9 @@
 From MetaRocq.Erasure Require EAst.
 From Peregrine Require Pipeline.
 From Peregrine Require ConfigUtils.
+From Peregrine Require RustGMPRemaps.
+From Peregrine Require RustNativeRemaps.
+From Peregrine Require RustMixedRemaps.
 From Peregrine Require SerializePrimitives.
 From Peregrine Require DeserializePrimitives.
 From Stdlib Require Import ExtrOcamlBasic.
@@ -70,6 +73,9 @@ Require compcert.cfrontend.Csyntax
 Separate Extraction Pipeline.peregrine_pipeline Pipeline.peregrine_validate
                     ConfigUtils.empty_rust_config' ConfigUtils.empty_elm_config' ConfigUtils.empty_certirocq_config'
                     ConfigUtils.empty_ocaml_config' ConfigUtils.empty_cakeml_config' ConfigUtils.empty_config'
+                    RustGMPRemaps.gmp_const_remaps RustGMPRemaps.gmp_ind_remaps RustGMPRemaps.gmp_rust_config'
+                    RustNativeRemaps.native_const_remaps RustNativeRemaps.native_ind_remaps RustNativeRemaps.native_rust_config'
+                    RustMixedRemaps.mixed_const_remaps RustMixedRemaps.mixed_ind_remaps RustMixedRemaps.mixed_rust_config'
                     Floats.Float32.to_bits Floats.Float.to_bits
                     Floats.Float32.of_bits Floats.Float.of_bits
                     Csyntax

--- a/theories/PAst.v
+++ b/theories/PAst.v
@@ -3,6 +3,7 @@ From MetaRocq.Erasure Require ExAst.
 From MetaRocq.Utils Require Import ResultMonad.
 From MetaRocq.Utils Require Import bytestring.
 From Peregrine Require Import Utils.
+From Peregrine Require Import EHindleyMilner.
 
 
 
@@ -25,8 +26,13 @@ Definition PAst_to_EAst (ast : PAst) : result' EAst.program :=
 
 Definition PAst_to_ExAst (ast : PAst) : result' ExAst.global_env :=
   match ast with
-  (* TODO: fix once we have type inference *)
-  | Untyped env _ => Err "Cannot convert untyped program to a typed program"%bs
+  (* Untyped (lambda-box) input is bridged to typed (lambda-box-typed) by the
+     verified Hindley-Milner section [infer]: [trans_env (infer empty_sigs env)
+     = env] (EHindleyMilner.infer_section), so erasure recovers the original
+     program.  [empty_sigs] supplies no datatype signatures; inference falls
+     back to [TAny] where a type is undetermined, which the section law tolerates
+     since the [box_type] annotations are erased away. *)
+  | Untyped env _ => Ok (infer empty_sigs env)
   | Typed env (Some t) => Ok env (* TODO: add t to env, with a fresh name or hardcoded main? *)
   | Typed env None => Ok env
   end.

--- a/theories/Pipeline.v
+++ b/theories/Pipeline.v
@@ -3,6 +3,8 @@ From Peregrine Require Import PAst.
 From Peregrine Require Import Config.
 From Peregrine Require Import ConfigUtils.
 From Peregrine Require Import Transforms.
+From Peregrine Require Import EHindleyMilner.
+From Peregrine Require Import EHMNumericSigs.
 From Peregrine Require Import Erasure.
 From Peregrine Require Import CheckWf.
 From Peregrine Require RustBackend.
@@ -71,12 +73,14 @@ Definition check_wf (p : PAst) : result' unit :=
 
 Definition validate_ast_type (c : config) (p : PAst) : result' unit :=
   match c.(backend_opts) with
-  | Rust _ => assert (is_typed_ast p) "Rust extraction requires typed lambda box input"
-  | Elm _ => assert (is_typed_ast p) "Elm extraction requires typed lambda box input"
+  (* Untyped (lambda-box) input is accepted for the typed backends: [PAst_to_ExAst]
+     bridges it to lambda-box-typed via the verified HM section [infer]. *)
+  | Rust _ => Ok tt
+  | Elm _ => Ok tt
   | C _ | Wasm _ | OCaml _ | CakeML _ | Eval _ => Ok tt
   | AST c =>
     match c.(ast_type) with
-    | LambdaBoxTyped => assert (is_typed_ast p) "Extraction requires typed lambda box input"
+    | LambdaBoxTyped => Ok tt
     | _ => Ok tt
     end
   end.
@@ -97,24 +101,36 @@ Definition apply_transforms (c : config) (p : PAst) (typed : bool) : result' PAs
   let cstr_reorder := mk_cstr_reorders c in
   let impl_box := c.(erasure_opts).(implement_box) in
   let impl_lazy := c.(erasure_opts).(implement_lazy) in
+  let spec_inst := c.(erasure_opts).(specialize_instances) in
   match p, typed with
-  | Untyped env (Some t), _ =>
-      let (env', t') := run_untyped_transforms econf cstr_reorder impl_box impl_lazy (env, t) in
+  | Untyped env (Some t), true =>
+      (* Typed backend on untyped (lambda-box) input: bridge to typed via the
+         verified HM section [infer] on the *raw* env (before the untyped
+         pipeline turns constructors into blocks, which the typed backends do
+         not consume), then run the typed pipeline, which preserves applied
+         constructors.  [infer_section] gives [trans_env (infer env) = env]. *)
+      let '(_, (env', t')) := run_typed_transforms econf cstr_reorder (infer numeric_sigs env, t) in
+      Ok (Typed env' (Some t'))
+  | Untyped env None, true =>
+      let '(_, (env', _)) := run_typed_transforms econf cstr_reorder (infer numeric_sigs env, EAst.tBox) in
+      Ok (Typed env' None)
+  | Untyped env (Some t), false =>
+      let (env', t') := run_untyped_transforms econf cstr_reorder spec_inst impl_box impl_lazy (env, t) in
       Ok (Untyped env' (Some t'))
-  | Untyped env None, _ =>
-      let (env', _) := run_untyped_transforms econf cstr_reorder impl_box impl_lazy (env, EAst.tBox) in
+  | Untyped env None, false =>
+      let (env', _) := run_untyped_transforms econf cstr_reorder spec_inst impl_box impl_lazy (env, EAst.tBox) in
       Ok (Untyped env' None)
   | Typed env (Some t), true =>
       let '(_, (env', t')) := run_typed_transforms econf cstr_reorder (env, t) in
       Ok (Typed env' (Some t'))
   | Typed env (Some t), false =>
-      let (env', t') := run_typed_to_untyped_transforms econf cstr_reorder impl_box impl_lazy (env, t) in
+      let (env', t') := run_typed_to_untyped_transforms econf cstr_reorder spec_inst impl_box impl_lazy (env, t) in
       (Ok (Untyped env' (Some t')))
   | Typed env None, true =>
       let '(_, (env', _)) := run_typed_transforms econf cstr_reorder (env, EAst.tBox) in
       Ok (Typed env' None)
   | Typed env None, false =>
-      let (env', _) := run_typed_to_untyped_transforms econf cstr_reorder impl_box impl_lazy (env, EAst.tBox) in
+      let (env', _) := run_typed_to_untyped_transforms econf cstr_reorder spec_inst impl_box impl_lazy (env, EAst.tBox) in
       (Ok (Untyped env' None))
   end.
 

--- a/theories/backends/ASTBackend.v
+++ b/theories/backends/ASTBackend.v
@@ -40,6 +40,7 @@ Definition ast_phases := {|
   unboxing_c       := Compatible false;
   dearg_ctors_c    := Compatible false;
   dearg_consts_c   := Compatible false;
+  specialize_instances_c := Compatible false;
 |}.
 
 Definition extract_untyped_ast (p : EAst.program)

--- a/theories/backends/CBackend.v
+++ b/theories/backends/CBackend.v
@@ -31,6 +31,7 @@ Definition c_phases := {|
   unboxing_c       := Compatible false;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/CakeMLBackend.v
+++ b/theories/backends/CakeMLBackend.v
@@ -30,6 +30,7 @@ Definition cakeml_phases := {|
   unboxing_c       := Compatible true;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/ElmBackend.v
+++ b/theories/backends/ElmBackend.v
@@ -31,6 +31,7 @@ Definition elm_phases := {|
   unboxing_c       := Compatible false;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/EvalBackend.v
+++ b/theories/backends/EvalBackend.v
@@ -36,6 +36,7 @@ Definition eval_phases := {|
   unboxing_c       := Compatible false;
   dearg_ctors_c    := Compatible false;
   dearg_consts_c   := Compatible false;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/LeanBackend.v
+++ b/theories/backends/LeanBackend.v
@@ -25,6 +25,7 @@ Definition lean_phases := {|
   unboxing_c       := Compatible false;
   dearg_ctors_c    := Compatible false;
   dearg_consts_c   := Compatible false;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/OCamlBackend.v
+++ b/theories/backends/OCamlBackend.v
@@ -33,6 +33,7 @@ Definition ocaml_phases := {|
   unboxing_c       := Compatible true;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/RustBackend.v
+++ b/theories/backends/RustBackend.v
@@ -84,13 +84,36 @@ Definition gmp_rust_config := {|
   rust_default_attributes := "#[derive(Debug, Clone)]";
 |}.
 
+(* [dearg_ctors_c]: whether to *trim* trailing dead bits off inductive
+   constructor dearging masks (an eta-expansion-avoidance micro-opt in
+   MetaRocq's typed dearging pass), as opposed to whether dearging runs at
+   all -- dead-argument analysis always runs regardless of this flag.
+   Left [Compatible true] (the trim), a fully-live (all-"keep") constructor
+   mask gets trimmed all the way down to the empty mask ([trim_end false]
+   strips *all* trailing [false] bits, and an all-live mask is all [false]).
+   [Optimize.check_oib_masks] then rejects that empty mask because its
+   length no longer equals the constructor's recorded arity (a strict `==`,
+   unlike the prefix-tolerant checks used elsewhere for constant masks and
+   for applying case-branch masks). That single rejection fails
+   [valid_masks_env] for the *whole program* (dearging is an all-or-nothing,
+   whole-environment check -- see [Transforms.dearg_diagnose]), which is why
+   completely ordinary types like [nat]/[list]/[prod] (whose "S"/"cons"/
+   "pair" constructors have no dead non-parameter fields to trim) silently
+   disabled dearging outright: every erased type-argument value-param
+   (Peregrine phase P4's "A: ()") stayed in the generated Rust for every
+   benchmark. Turning trimming off avoids ever producing such an
+   empty-but-should-be-full-length mask; per-argument/per-field dead-code
+   removal (both constant args, via [dearg_consts_c], and constructor
+   fields) is unaffected -- only the harmless trailing-bits compaction is
+   skipped. Confirmed empirically with the `deargdiag` diagnostic and a
+   5/5 rustb correctness re-run (see phase P4 report). *)
 Definition rust_phases := {|
   implement_box_c  := Compatible false;
   implement_lazy_c := Compatible false;
   cofix_to_laxy_c  := Compatible false;
   betared_c        := Compatible false;
   unboxing_c       := Compatible true;
-  dearg_ctors_c    := Compatible true;
+  dearg_ctors_c    := Compatible false;
   dearg_consts_c   := Compatible true;
   specialize_instances_c := Compatible false;
 |}.

--- a/theories/backends/RustBackend.v
+++ b/theories/backends/RustBackend.v
@@ -23,14 +23,76 @@ Definition default_rust_config := {|
   rust_default_attributes := "#[derive(Debug, Clone)]";
 |}.
 
+(** GMP runtime preamble: helpers + eliminator macros over [rug::Integer],
+    the GMP analogue of the u64 helpers hardcoded in PluginExtract.v.  Place
+    this in [rust_preamble_top] (see [gmp_rust_config]).  Requires the [rug]
+    crate: add [rug = "1"] to the generated Cargo.toml.  Validate against a
+    real build — the eliminator/predecessor paths are the least-tested. *)
+Definition rust_gmp_preamble : string :=
+  String.concat MRString.nl [
+  "use rug::Integer;";
+  "";
+  "fn __nat_succ(x: Integer) -> Integer { x + 1 }";
+  "macro_rules! __nat_elim {";
+  "  ($zcase:expr, $pred:ident, $scase:expr, $val:expr) => {";
+  "    { let v = $val; if v == 0 { $zcase } else { let $pred = Integer::from(&v - 1); $scase } }";
+  "  }";
+  "}";
+  "macro_rules! __andb { ($b1:expr, $b2:expr) => { $b1 && $b2 } }";
+  "macro_rules! __orb { ($b1:expr, $b2:expr) => { $b1 || $b2 } }";
+  "";
+  "fn __pos_onebit(x: Integer) -> Integer { x * 2 + 1 }";
+  "fn __pos_zerobit(x: Integer) -> Integer { x * 2 }";
+  "macro_rules! __pos_elim {";
+  "  ($p:ident, $onebcase:expr, $p2:ident, $zerobcase:expr, $onecase:expr, $val:expr) => {";
+  "    { let n = $val;";
+  "      if n == 1 { $onecase }";
+  "      else if Integer::from(&n & Integer::from(1)) == 0 { let $p2 = Integer::from(&n >> 1u32); $zerobcase }";
+  "      else { let $p = Integer::from(&n >> 1u32); $onebcase } }";
+  "  }";
+  "}";
+  "";
+  "fn __N_frompos(z: Integer) -> Integer { z }";
+  "macro_rules! __N_elim {";
+  "  ($zero_case:expr, $p:ident, $pos_case:expr, $val:expr) => {";
+  "    { let $p = $val; if $p == 0 { $zero_case } else { $pos_case } }";
+  "  }";
+  "}";
+  "";
+  "fn __Z_frompos(z: Integer) -> Integer { z }";
+  "fn __Z_fromneg(z: Integer) -> Integer { -z }";
+  "macro_rules! __Z_elim {";
+  "  ($zero_case:expr, $p:ident, $pos_case:expr, $p2:ident, $neg_case:expr, $val:expr) => {";
+  "    { let n = $val;";
+  "      if n == 0 { $zero_case }";
+  "      else if n < 0 { let $p2 = Integer::from(-&n); $neg_case }";
+  "      else { let $p = n; $pos_case } }";
+  "  }";
+  "}"
+  ].
+
+(** As [default_rust_config] but with the GMP numeric preamble wired into the
+    top preamble.  Pair this with the GMP constant/inductive remaps (the config
+    counterparts of ExtrRustGMP.v) to make [compile_rust] emit GMP arithmetic. *)
+Definition gmp_rust_config := {|
+  rust_preamble_top       := rust_gmp_preamble;
+  rust_preamble_program   := "";
+  rust_term_box_symbol    := "()";
+  rust_type_box_symbol    := "()";
+  rust_any_type_symbol    := "()";
+  rust_print_full_names   := true;
+  rust_default_attributes := "#[derive(Debug, Clone)]";
+|}.
+
 Definition rust_phases := {|
   implement_box_c  := Compatible false;
   implement_lazy_c := Compatible false;
   cofix_to_laxy_c  := Compatible false;
   betared_c        := Compatible false;
-  unboxing_c       := Compatible false;
+  unboxing_c       := Compatible true;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/backends/RustGMPRemaps.v
+++ b/theories/backends/RustGMPRemaps.v
@@ -1,0 +1,243 @@
+(** Config-path (CLI) equivalent of the plugin's ExtrRustGMP.v numeric remap,
+    using an ARENA-ALLOCATED SHARED-REFERENCE representation.
+
+    The Rust backend stores every extracted value under a pervasive [<A: Copy>]
+    bound: inductives are [&'a Enum] references and closures are [&'a dyn Fn],
+    all [Copy] references into a [bumpalo] arena.  An OWNED [rug::Integer] is not
+    [Copy], so the moment a number is placed in a [list]/pair/tree the generic
+    machinery fails to compile (E0277).  We therefore represent the GMP numeric
+    types as [&'a rug::Integer] (a shared reference, hence [Copy]), matching the
+    backend's architecture.  A number lives in the same arena as everything else.
+
+    Representation summary:
+      - [nat]/[positive]/[N]/[Z]  ==>  [&'a rug::Integer]  (alias [Int<'a>]).
+      - Constructors are emitted as [self.]-methods that arena-allocate the
+        result (they are spliced inside [impl] method bodies where [self] is in
+        scope), e.g. ctor strings ["self.__nat_zero()"], ["self.__nat_succ"].
+      - Arithmetic ops are [&'a self] methods that arena-allocate their result.
+      - Eliminators are [macro_rules!] (no [self] available); the predecessor,
+        which must be an [&'a rug::Integer], is produced with
+        [Box::leak(Box::new(..))] (a [&'static] that coerces to [&'a]).  Leaks
+        are bounded by the recursion depth and GMP ints are compact; the arena
+        itself never frees either.
+
+    The matching runtime preamble is split in two: [gmp_top_preamble] (outside
+    the [impl]: [use]s, the [Int] alias, the eliminator/bool macros) and
+    [gmp_program_preamble] (inside [impl<'a> Program]: the constructor methods).
+    Cargo dependencies: [rug = "1"], [bumpalo = "3"].
+
+    NOTE: the eliminator match strings carry the [!] macro-invocation suffix
+    (e.g. "__nat_elim!") because the Rust backend emits [eliminator ^ "("]
+    verbatim (RustExtract.print_remapped_case) and the preamble defines these
+    as [macro_rules!]. *)
+
+From MetaRocq.Common Require Import Kernames.
+From MetaRocq.Utils Require Import bytestring.
+From Peregrine Require Import Config.
+From Peregrine Require Import ConfigUtils.
+From Peregrine Require Import RustBackend.
+From TypedExtraction Require Import Common.
+
+From Stdlib Require Import Arith.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import NArith.
+From Stdlib Require Import PArith.
+From Stdlib Require Import List.
+Import ListNotations.
+
+Local Open Scope bs_scope.
+
+(** Smart constructor for a Rust constant remap: only [re_const_inl] (false =
+    emit as a definition) and [re_const_s] (the Rust body, with [##name##]
+    replaced by the mangled function name) are consulted by the Rust backend;
+    the other fields are C/Wasm-only and left at defaults. *)
+Definition mk_const (s : string) : remapped_constant := {|
+  re_const_ext   := None;
+  re_const_arity := 0;
+  re_const_gc    := false;
+  re_const_inl   := false;
+  re_const_s     := s;
+|}.
+
+Definition mk_ind (name : string) (ctors : list string) (m : option string)
+  : remapped_inductive :=
+  {| re_ind_name  := name;
+     re_ind_ctors := ctors;
+     re_ind_match := m |}.
+
+Definition ind_remap (i : inductive) (name : string) (ctors : list string)
+                     (m : option string) : remap_inductive :=
+  StringIndRemap i (mk_ind name ctors m).
+
+(** The numeric type name spliced wherever a [nat]/[N]/[Z]/[positive] appears as
+    a Rust type ([RustExtract.print_type_aux], [TInd] branch).  [Int<'a>] keeps
+    the arena lifetime in scope; it is a type alias for [&'a rug::Integer] (see
+    [gmp_top_preamble]).  Constructor strings are emitted either as a bare 0-arg
+    method call ([self.__nat_zero()]) or as a method head applied to arguments
+    ([self.__nat_succ(x)]). *)
+Definition gmp_ind_remaps : inductive_remappings := [
+  (* [bool] -> native Rust [bool].  Coq constructor order is [true] (0) then
+     [false] (1); a match becomes [__bool_elim!(tcase, fcase, discr)]. *)
+  ind_remap {| inductive_mind := <%% bool %%>; inductive_ind := 0 |}
+    "bool" ["true"; "false"] (Some "__bool_elim!");
+  ind_remap {| inductive_mind := <%% nat %%>; inductive_ind := 0 |}
+    "Int<'a>" ["self.__nat_zero()"; "self.__nat_succ"] (Some "__nat_elim!");
+  ind_remap {| inductive_mind := <%% positive %%>; inductive_ind := 0 |}
+    "Int<'a>" ["self.__pos_onebit"; "self.__pos_zerobit"; "self.__pos_one()"]
+    (Some "__pos_elim!");
+  ind_remap {| inductive_mind := <%% N %%>; inductive_ind := 0 |}
+    "Int<'a>" ["self.__N_zero()"; "self.__N_frompos"] (Some "__N_elim!");
+  ind_remap {| inductive_mind := <%% Z %%>; inductive_ind := 0 |}
+    "Int<'a>" ["self.__Z_zero()"; "self.__Z_frompos"; "self.__Z_fromneg"]
+    (Some "__Z_elim!")
+].
+
+Definition gmp_const_remaps : constant_remappings := [
+  (* --- positive --- *)
+  (<%% Pos.add %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + b)) }");
+  (<%% Pos.succ %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + 1)) }");
+  (<%% Pos.pred %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - 1).max(rug::Integer::from(1))) }");
+  (<%% Pos.sub %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - b)) }");
+  (<%% Pos.mul %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a * b)) }");
+  (<%% Pos.min %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a <= b { a } else { b } }");
+  (<%% Pos.max %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a >= b { a } else { b } }");
+  (<%% Pos.eqb %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { a == b }");
+  (<%% Pos.compare %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> std::cmp::Ordering { a.cmp(b) }");
+
+  (* --- N --- *)
+  (<%% N.add %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + b)) }");
+  (<%% N.succ %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + 1)) }");
+  (<%% N.pred %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - 1).max(rug::Integer::new())) }");
+  (<%% N.sub %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - b).max(rug::Integer::new())) }");
+  (<%% N.mul %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a * b)) }");
+  (<%% N.div %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if *b == 0 { self.alloc(rug::Integer::new()) } else { self.alloc(rug::Integer::from(a / b)) } }");
+  (<%% N.modulo %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if *b == 0 { a } else { self.alloc(rug::Integer::from(a % b)) } }");
+  (<%% N.min %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a <= b { a } else { b } }");
+  (<%% N.max %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a >= b { a } else { b } }");
+  (<%% N.eqb %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { a == b }");
+  (<%% N.compare %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> std::cmp::Ordering { a.cmp(b) }");
+
+  (* --- Z --- *)
+  (<%% Z.add %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + b)) }");
+  (<%% Z.succ %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + 1)) }");
+  (<%% Z.pred %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - 1)) }");
+  (<%% Z.sub %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - b)) }");
+  (<%% Z.mul %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a * b)) }");
+  (<%% Z.opp %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(-a)) }");
+  (<%% Z.min %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a <= b { a } else { b } }");
+  (<%% Z.max %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a >= b { a } else { b } }");
+  (<%% Z.eqb %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { a == b }");
+  (<%% Z.div %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if *b == 0 { self.alloc(rug::Integer::new()) } else { self.alloc(rug::Integer::from(a).div_floor(rug::Integer::from(b))) } }");
+  (<%% Z.modulo %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if *b == 0 { a } else { self.alloc(rug::Integer::from(a).rem_floor(rug::Integer::from(b))) } }");
+  (<%% Z.compare %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> std::cmp::Ordering { a.cmp(b) }");
+  (<%% Z.of_N %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { a }");
+  (<%% Z.abs_N %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a.abs_ref())) }");
+
+  (* --- nat --- *)
+  (<%% Nat.add %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a + b)) }");
+  (<%% Nat.mul %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a * b)) }");
+  (<%% Nat.sub %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a - b).max(rug::Integer::new())) }");
+  (<%% Nat.eqb %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { a == b }");
+  (<%% Nat.leb %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { a <= b }");
+  (<%% Nat.ltb %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { a < b }");
+  (<%% Nat.compare %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> std::cmp::Ordering { a.cmp(b) }");
+  (<%% Nat.max %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a >= b { a } else { b } }");
+  (<%% Nat.min %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if a <= b { a } else { b } }");
+  (<%% Nat.div %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if *b == 0 { self.alloc(rug::Integer::new()) } else { self.alloc(rug::Integer::from(a / b)) } }");
+  (<%% Nat.modulo %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { if *b == 0 { a } else { self.alloc(rug::Integer::from(a % b)) } }");
+  (* Nat.pow remaps to GMP exponentiation (exponent fits u32 for benchmark
+     inputs), avoiding an extracted recursive nat closure. *)
+  (<%% Nat.pow %%>, mk_const "fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(a).pow(b.to_u32().unwrap())) }")
+].
+
+(** Top-of-file preamble (outside [impl<'a> Program]): imports, the [Int] type
+    alias, the eliminator macros over [&'a rug::Integer], and the bool macros.
+    The eliminators dereference the reference for comparisons and [Box::leak] the
+    predecessor (a [&'static] that coerces to [&'a]). *)
+Definition gmp_top_preamble : string :=
+  String.concat MRString.nl [
+  "use rug::Integer;";
+  "use rug::ops::{DivRounding, RemRounding, Pow};";
+  "type Int<'a> = &'a rug::Integer;";
+  "";
+  "macro_rules! __andb { ($b1:expr, $b2:expr) => { $b1 && $b2 } }";
+  "macro_rules! __orb { ($b1:expr, $b2:expr) => { $b1 || $b2 } }";
+  "macro_rules! __bool_elim { ($tcase:expr, $fcase:expr, $val:expr) => { if $val { $tcase } else { $fcase } } }";
+  "";
+  "macro_rules! __nat_elim {";
+  "  ($zcase:expr, $pred:ident, $scase:expr, $val:expr) => {";
+  "    { let v: &rug::Integer = $val;";
+  "      if *v == 0 { $zcase }";
+  "      else { let $pred: &rug::Integer = Box::leak(Box::new(rug::Integer::from(v - 1))); $scase } }";
+  "  }";
+  "}";
+  "";
+  "macro_rules! __pos_elim {";
+  "  ($p:ident, $onebcase:expr, $p2:ident, $zerobcase:expr, $onecase:expr, $val:expr) => {";
+  "    { let n: &rug::Integer = $val;";
+  "      if *n == 1 { $onecase }";
+  "      else if n.is_odd() { let $p: &rug::Integer = Box::leak(Box::new(rug::Integer::from(n >> 1u32))); $onebcase }";
+  "      else { let $p2: &rug::Integer = Box::leak(Box::new(rug::Integer::from(n >> 1u32))); $zerobcase } }";
+  "  }";
+  "}";
+  "";
+  "macro_rules! __N_elim {";
+  "  ($zero_case:expr, $p:ident, $pos_case:expr, $val:expr) => {";
+  "    { let $p: &rug::Integer = $val; if *$p == 0 { $zero_case } else { $pos_case } }";
+  "  }";
+  "}";
+  "";
+  "macro_rules! __Z_elim {";
+  "  ($zero_case:expr, $p:ident, $pos_case:expr, $p2:ident, $neg_case:expr, $val:expr) => {";
+  "    { let n: &rug::Integer = $val;";
+  "      if *n == 0 { $zero_case }";
+  "      else if *n < 0 { let $p2: &rug::Integer = Box::leak(Box::new(rug::Integer::from(-n))); $neg_case }";
+  "      else { let $p = n; $pos_case } }";
+  "  }";
+  "}"
+  ].
+
+(** Program preamble (inside [impl<'a> Program], after [alloc]/[closure]): the
+    constructor methods.  Each arena-allocates its result and returns
+    [&'a rug::Integer], so a constructor produces the same [Copy] reference shape
+    the backend expects.  [__N_frompos]/[__Z_frompos]/[Z.of_N] are identities on
+    the reference. *)
+Definition gmp_program_preamble : string :=
+  String.concat MRString.nl [
+  "fn __nat_zero(&'a self) -> &'a rug::Integer { self.alloc(rug::Integer::new()) }";
+  "fn __nat_succ(&'a self, x: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(x + 1)) }";
+  "fn __pos_one(&'a self) -> &'a rug::Integer { self.alloc(rug::Integer::from(1)) }";
+  "fn __pos_onebit(&'a self, x: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(x * 2) + 1) }";
+  "fn __pos_zerobit(&'a self, x: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(x * 2)) }";
+  "fn __N_zero(&'a self) -> &'a rug::Integer { self.alloc(rug::Integer::new()) }";
+  "fn __N_frompos(&'a self, z: &'a rug::Integer) -> &'a rug::Integer { z }";
+  "fn __Z_zero(&'a self) -> &'a rug::Integer { self.alloc(rug::Integer::new()) }";
+  "fn __Z_frompos(&'a self, z: &'a rug::Integer) -> &'a rug::Integer { z }";
+  "fn __Z_fromneg(&'a self, z: &'a rug::Integer) -> &'a rug::Integer { self.alloc(rug::Integer::from(-z)) }"
+  ].
+
+(** Optional Rust config (CLI path) with the GMP preambles wired in.  Slots into
+    [ConfigUtils.Rust'] for the [peregrine] binary; all other fields fall through
+    to [default_rust_config]. *)
+Definition gmp_rust_config' : rust_config' := {|
+  rust_preamble_top'       := Some gmp_top_preamble;
+  rust_preamble_program'   := Some gmp_program_preamble;
+  rust_term_box_symbol'    := None;
+  rust_type_box_symbol'    := None;
+  rust_any_type_symbol'    := None;
+  rust_print_full_names'   := None;
+  rust_default_attributes' := None;
+|}.
+
+(** Full (non-optional) Rust config for driving [extract_rust] directly (test
+    harness path).  Mirrors [gmp_rust_config] (RustBackend.v) but with the
+    reference-representation preambles. *)
+Definition gmp_rust_config_full : rust_config := {|
+  rust_preamble_top       := gmp_top_preamble;
+  rust_preamble_program   := gmp_program_preamble;
+  rust_term_box_symbol    := "()";
+  rust_type_box_symbol    := "()";
+  rust_any_type_symbol    := "()";
+  rust_print_full_names   := true;
+  rust_default_attributes := "#[derive(Debug, Clone)]";
+|}.

--- a/theories/backends/RustMixedCoherence.v
+++ b/theories/backends/RustMixedCoherence.v
@@ -1,0 +1,237 @@
+(** * Coercion-coherence for Peregrine's mixed-representation Rust backend.
+
+    This file formalises the mathematically-substantive coherence facts that
+    justify the [Path C] mixed numeric backend defined in
+    [theories/backends/RustMixedRemaps.v].
+
+    Background (see the header of RustMixedRemaps.v).  Coq [nat]/[Z] numerics
+    are extracted by default in PATH A: arbitrary-precision [&'a rug::Integer].
+    A directive-selected PARTITION of operations ([b_partition]) is instead
+    compiled in PATH B: native [i64].  Each B-body coerces its arguments down
+    to [i64] at entry ([__to_i64]), computes natively, and coerces the result
+    back up ([__from_i64]).  Those two coercions form the A<->B boundary.
+
+    We model the two representations abstractly, both as the mathematical
+    integer they denote:
+
+      - PATH A value  = the integer itself.
+      - PATH B value  = the integer, CONSTRAINED to the i64 window [in_i64].
+      - [to_i64] / [from_i64] = identity on the modelled integer, valid exactly
+        on the [in_i64] window (outside it the real [.to_i64().unwrap()] would
+        panic; the [in_i64] precondition is what discharges the [.unwrap()]).
+
+    Everything below is proved against Rocq's standard [ZArith].  The ONE thing
+    Rocq cannot see is the Rust source string emitted by each remap; that
+    per-string "the emitted Rust realises this modelled function on its domain"
+    obligation is collected in the TRUSTED BRIDGE block at the end of the file.
+
+    Rocq 9.1 / Stdlib. *)
+
+From Stdlib Require Import ZArith Lia.
+
+Local Open Scope Z_scope.
+
+(* ------------------------------------------------------------------ *)
+(** ** The i64 window and the boundary coercions *)
+
+(** The signed 64-bit range: exactly the values for which [rug::Integer::to_i64]
+    succeeds (its [.unwrap()] does not panic). *)
+Definition in_i64 (z : Z) : Prop := (-2^63 <= z < 2^63)%Z.
+
+(** The A->B coercion, modelled on the denoted integer.  On the [in_i64] window
+    the real [__to_i64] is the identity on the value it denotes. *)
+Definition to_i64_spec (z : Z) : Z := z.
+
+(** The B->A coercion, modelled on the denoted integer.  [__from_i64] injects an
+    [i64] back into an arbitrary-precision integer; on the modelled value it is
+    the identity. *)
+Definition from_i64_spec (z : Z) : Z := z.
+
+(** The A<->B boundary is coherent: coercing down then back up is the identity
+    on the whole i64 window.  (The [in_i64] hypothesis is what makes the real
+    [.to_i64().unwrap()] total; on the model the roundtrip is unconditional.) *)
+Theorem coerce_roundtrip :
+  forall z, in_i64 z -> from_i64_spec (to_i64_spec z) = z.
+Proof.
+  intros z _. unfold from_i64_spec, to_i64_spec. reflexivity.
+Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** Generic op-coherence *)
+
+(** A native (path-B) binary op [g : Z -> Z -> Z] realises the Coq (path-A)
+    [nat] op [f] when, on arguments that fit i64 and whose result fits i64,
+    running B (coerce down, apply [g], coerce back) reproduces the [nat]
+    meaning [Z.of_nat (f a b)].
+
+    The three [in_i64] premises are precisely the side-conditions under which
+    the two [__to_i64] calls and the one [__from_i64] call in the emitted body
+    are total (no [.unwrap()] panic and no i64 overflow). *)
+Definition op_coherent (f : nat -> nat -> nat) (g : Z -> Z -> Z) : Prop :=
+  forall a b,
+    in_i64 (Z.of_nat a) ->
+    in_i64 (Z.of_nat b) ->
+    in_i64 (Z.of_nat (f a b)) ->
+    from_i64_spec (g (to_i64_spec (Z.of_nat a)) (to_i64_spec (Z.of_nat b)))
+      = Z.of_nat (f a b).
+
+(* ------------------------------------------------------------------ *)
+(** ** The b_partition instances
+
+    Each theorem below corresponds to one entry of [b_partition] in
+    RustMixedRemaps.v, pairing the Coq [nat] op with the [Z] model of its
+    emitted native i64 expression. *)
+
+(** [Nat.add]  <->  b2i "a + b" *)
+Theorem coherent_add : op_coherent Nat.add Z.add.
+Proof.
+  intros a b _ _ _. unfold from_i64_spec, to_i64_spec.
+  rewrite Nat2Z.inj_add. reflexivity.
+Qed.
+
+(** [Nat.mul]  <->  b2i "a * b" *)
+Theorem coherent_mul : op_coherent Nat.mul Z.mul.
+Proof.
+  intros a b _ _ _. unfold from_i64_spec, to_i64_spec.
+  rewrite Nat2Z.inj_mul. reflexivity.
+Qed.
+
+(** [Nat.sub]  <->  b2i "if a - b < 0 { 0 } else { a - b }".
+    The native body is saturating (truncated at 0), matching Coq's truncated
+    [nat] subtraction.  Modelled as [Z.max 0 (a - b)]. *)
+Theorem coherent_sub :
+  op_coherent Nat.sub (fun x y => Z.max 0 (x - y)).
+Proof.
+  intros a b _ _ _. unfold from_i64_spec, to_i64_spec.
+  (* [lia]'s zify preprocessing knows both truncated [Nat.sub] (through
+     [Z.of_nat]) and [Z.max], so the saturating identity is closed directly. *)
+  lia.
+Qed.
+
+(** [Nat.div]  <->  b2i "if b == 0 { 0 } else { a / b }".
+    Coq's [Nat.div a 0 = 0] and Rust's guard both return 0 on a zero divisor;
+    off zero the divisor is positive so truncated [i64] division ([Z.div] on
+    nonnegatives) agrees with [Nat.div]. *)
+Theorem coherent_div :
+  op_coherent Nat.div (fun x y => if Z.eqb y 0 then 0 else x / y).
+Proof.
+  intros a b _ _ _. unfold from_i64_spec, to_i64_spec.
+  destruct (Z.of_nat b =? 0) eqn:E.
+  - (* divisor is zero: guard returns 0, and [Nat.div a 0] computes to 0. *)
+    apply Z.eqb_eq in E.
+    assert (b = 0)%nat by lia. subst b.
+    reflexivity.
+  - (* divisor nonzero: native division matches [Nat.div] via [Nat2Z.inj_div]. *)
+    rewrite <- Nat2Z.inj_div. reflexivity.
+Qed.
+
+(** [Nat.modulo]  <->  b2i "if b == 0 { a } else { a % b }".
+    Coq's [Nat.modulo a 0 = a] and Rust's guard both return [a] on a zero
+    divisor; off zero, on nonnegative operands Rust's truncated remainder [%]
+    coincides with Euclidean [Z.modulo], which matches [Nat.modulo] via
+    [Nat2Z.inj_mod]. *)
+Theorem coherent_mod :
+  op_coherent Nat.modulo (fun x y => if Z.eqb y 0 then x else Z.modulo x y).
+Proof.
+  intros a b _ _ _. unfold from_i64_spec, to_i64_spec.
+  destruct (Z.of_nat b =? 0) eqn:E.
+  - (* divisor is zero: guard returns [a], and [Nat.modulo a 0] computes to [a]. *)
+    apply Z.eqb_eq in E.
+    assert (b = 0)%nat by lia. subst b.
+    reflexivity.
+  - (* divisor nonzero: native remainder matches [Nat.modulo] via [Nat2Z.inj_mod]. *)
+    rewrite <- Nat2Z.inj_mod. reflexivity.
+Qed.
+
+(** Remark on [Nat.pow]  <->  b2i "a.pow(b as u32)".
+    This entry of [b_partition] is intentionally NOT given an [op_coherent]
+    theorem here.  Its native body casts the exponent [b as u32], so its
+    modelled function is only faithful on the restricted domain [b < 2^32]
+    (and, as for every B-op, on results within [in_i64]).  That domain
+    restriction is a property of the emitted string, so it is discharged in the
+    TRUSTED BRIDGE block below rather than as a numeric coherence lemma. *)
+
+(* ------------------------------------------------------------------ *)
+(** ** Comparison predicates (b2b)
+
+    These return a native [bool] in BOTH paths (bool is represented natively
+    everywhere), so there is no [__from_i64] coercion back.  Coherence is just:
+    the native [Z] boolean test equals the Coq [nat] boolean test. *)
+
+(** [Nat.eqb]  <->  b2b "a == b" *)
+Theorem coherent_eqb :
+  forall a b,
+    in_i64 (Z.of_nat a) -> in_i64 (Z.of_nat b) ->
+    Nat.eqb a b = Z.eqb (Z.of_nat a) (Z.of_nat b).
+Proof.
+  intros a b _ _. destruct (Nat.eqb a b) eqn:E.
+  - apply Nat.eqb_eq in E. subst. symmetry. apply Z.eqb_eq. reflexivity.
+  - apply Nat.eqb_neq in E. symmetry. apply Z.eqb_neq. lia.
+Qed.
+
+(** [Nat.leb]  <->  b2b "a <= b" *)
+Theorem coherent_leb :
+  forall a b,
+    in_i64 (Z.of_nat a) -> in_i64 (Z.of_nat b) ->
+    Nat.leb a b = Z.leb (Z.of_nat a) (Z.of_nat b).
+Proof.
+  intros a b _ _. destruct (Nat.leb a b) eqn:E.
+  - apply Nat.leb_le in E. symmetry. apply Z.leb_le. lia.
+  - apply Nat.leb_gt in E. symmetry. apply Z.leb_gt. lia.
+Qed.
+
+(** [Nat.ltb]  <->  b2b "a < b" *)
+Theorem coherent_ltb :
+  forall a b,
+    in_i64 (Z.of_nat a) -> in_i64 (Z.of_nat b) ->
+    Nat.ltb a b = Z.ltb (Z.of_nat a) (Z.of_nat b).
+Proof.
+  intros a b _ _. destruct (Nat.ltb a b) eqn:E.
+  - apply Nat.ltb_lt in E. symmetry. apply Z.ltb_lt. lia.
+  - apply Nat.ltb_ge in E. symmetry. apply Z.ltb_ge. lia.
+Qed.
+
+(* ================================================================== *)
+(** ** TRUSTED BRIDGE (meta-level, per Rust string)
+
+    Everything above is fully machine-checked against Rocq's [ZArith].  The
+    proofs relate the Coq [nat] operations to their [Z] MODELS of the native
+    i64 expressions.  What Rocq cannot inspect is the concrete Rust source
+    string that Peregrine emits for each remap (the strings live in
+    [theories/backends/RustMixedRemaps.v] as opaque [string]s).  The remaining,
+    UNVERIFIED obligation is that each emitted string really computes its
+    modelled function on its stated domain.  Concretely, we ASSUME:
+
+    - The coercion preamble ([mixed_coercions]):
+        * "fn __to_i64(&'a self, x) -> i64 { x.to_i64().unwrap() }"
+          realises [to_i64_spec] on the domain [in_i64], and the [.unwrap()]
+          never panics there -- justified by the [in_i64] premise, which is
+          exactly the totality condition of [rug::Integer::to_i64].
+        * "fn __from_i64(&'a self, x: i64) -> ... { self.alloc(Integer::from(x)) }"
+          realises [from_i64_spec] (the identity injection i64 -> Integer).
+
+    - Each [b_partition] body realises its modelled [Z] function on
+      arguments/results within [in_i64] (i.e. the native [i64] arithmetic does
+      not overflow, guaranteed by the third [in_i64] premise of [op_coherent]):
+        * "a + b"                              realises  [Z.add]        (coherent_add)
+        * "a * b"                              realises  [Z.mul]        (coherent_mul)
+        * "if a - b < 0 { 0 } else { a - b }"  realises  [fun x y => Z.max 0 (x - y)]
+                                                                        (coherent_sub)
+        * "if b == 0 { 0 } else { a / b }"     realises  [fun x y => if y =? 0 then 0 else x / y]
+                                                                        (coherent_div)
+        * "if b == 0 { a } else { a % b }"     realises  [fun x y => if y =? 0 then x else Z.modulo x y]
+                                                                        (coherent_mod)
+        * "a.pow(b as u32)"                    realises  [Z.pow] on the RESTRICTED
+                                               domain [Z.of_nat b < 2^32] (see the
+                                               [Nat.pow] remark above); not given a
+                                               numeric coherence lemma here.
+        * "a == b"                             realises  [Z.eqb]        (coherent_eqb)
+        * "a <= b"                             realises  [Z.leb]        (coherent_leb)
+        * "a < b"                              realises  [Z.ltb]        (coherent_ltb)
+
+    Under these per-string assumptions, the theorems above establish that every
+    op in [b_partition] agrees with its path-A meaning on the coerced values;
+    hence the mixed backend is sound INDEPENDENTLY of which ops are placed in
+    the B partition -- the partition is a pure performance choice, exactly as
+    claimed in the RustMixedRemaps.v header.  This trusted bridge is the only
+    unverified part of the coherence argument. *)

--- a/theories/backends/RustMixedRemaps.v
+++ b/theories/backends/RustMixedRemaps.v
@@ -45,8 +45,22 @@ Definition b2i (e : string) : remapped_constant :=
 Definition b2b (e : string) : remapped_constant :=
   mk_const ("fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { let a = self.__to_i64(a); let b = self.__to_i64(b); " ++ e ++ " }").
 
-(** The B partition: the (nat) operations compiled natively.  Placed BEFORE the
-    path-A [gmp_const_remaps] so they take precedence in remap lookup. *)
+(** The B partition is a DIRECTIVE, not a fixed property of the backend: it is
+    just a list of (constant, native-body) remaps, and [mixed_const_remaps_of]
+    builds the full remap table by putting the chosen partition BEFORE the
+    path-A [gmp_const_remaps] (so B entries take precedence in remap lookup,
+    and every op not named by the partition falls through to path A).  Since
+    every [b2i]/[b2b] body is proved-at-the-boundary equivalent to the path-A
+    meaning of the same op (coerce in, compute, coerce out), swapping which
+    ops are named by the partition can never change the result -- only the
+    performance profile.  That is the "partition is a performance oracle"
+    principle: correctness comes from the coercion discipline, not from which
+    ops happen to be in [b_partition]. *)
+Definition mixed_const_remaps_of (partition : constant_remappings) : constant_remappings :=
+  (partition ++ gmp_const_remaps)%list.
+
+(** Partition 1 (the original, maximal partition): all nine core nat
+    operations run natively in path B. *)
 Definition b_partition : constant_remappings := [
   (<%% Nat.add %%>,    b2i "a + b");
   (<%% Nat.mul %%>,    b2i "a * b");
@@ -59,8 +73,24 @@ Definition b_partition : constant_remappings := [
   (<%% Nat.ltb %%>,    b2b "a < b")
 ].
 
+(** Partition 2 (a strictly narrower alternative): only the three operations
+    that are expensive to keep arbitrary-precision (div/mod/pow) run
+    natively; add/mul/sub/eqb/leb/ltb stay in path A (GMP).  This is a
+    DIFFERENT partition from [b_partition] -- fewer ops in B, more in A --
+    yet it is compiled and validated exactly the same way, demonstrating
+    that correctness does not depend on which partition is chosen. *)
+Definition narrow_b_partition : constant_remappings := [
+  (<%% Nat.div %%>,    b2i "if b == 0 { 0 } else { a / b }");
+  (<%% Nat.modulo %%>, b2i "if b == 0 { a } else { a % b }");
+  (<%% Nat.pow %%>,    b2i "a.pow(b as u32)")
+].
+
 Definition mixed_const_remaps : constant_remappings :=
-  (b_partition ++ gmp_const_remaps)%list.
+  mixed_const_remaps_of b_partition.
+
+(** Same mixed backend, alternative (narrower) partition: [rustm2]. *)
+Definition mixed_const_remaps2 : constant_remappings :=
+  mixed_const_remaps_of narrow_b_partition.
 
 (** The nat/Z/N/positive TYPE stays path A ([Int<'a>]); constructors and
     eliminators are the path-A (GMP) ones. *)

--- a/theories/backends/RustMixedRemaps.v
+++ b/theories/backends/RustMixedRemaps.v
@@ -1,0 +1,88 @@
+(** Path C: MIXED-representation numeric backend.
+
+    Values live in path A (arbitrary-precision [&'a rug::Integer]) by default, so
+    the program is correct for all inputs.  A directive-selected PARTITION of
+    operations is compiled in path B (native [i64]): those remap bodies coerce
+    their [&'a rug::Integer] arguments down to [i64] at entry ([__to_i64]),
+    compute natively, and coerce the result back up ([__from_i64]).  The two
+    coercions are the A<->B boundary.
+
+    Correctness is INDEPENDENT of the partition: any operation whose B body
+    agrees with its A meaning on the coerced values is sound, so which ops are in
+    the B partition is purely a performance choice (the partition is an untrusted
+    oracle).  Here the partition is given explicitly ([b_partition]); a static
+    analysis or a Rocq attribute could populate it automatically.
+
+    This is the minimal, per-operation realisation of the mixed backend: the two
+    representations coexist in one generated crate, joined by coherent coercions.
+    A per-function partition (switching the nat REPRESENTATION inside a function,
+    not just at op boundaries) is the natural next granularity. *)
+
+From MetaRocq.Common Require Import Kernames.
+From MetaRocq.Utils Require Import bytestring.
+From Peregrine Require Import Config.
+From Peregrine Require Import ConfigUtils.
+From Peregrine Require Import RustBackend.
+From Peregrine Require Import RustGMPRemaps.
+From TypedExtraction Require Import Common.
+
+From Stdlib Require Import Arith.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import NArith.
+From Stdlib Require Import PArith.
+From Stdlib Require Import List.
+Import ListNotations.
+
+Local Open Scope bs_scope.
+
+(** A binary op run in path B: coerce both [&'a rug::Integer] args to [i64],
+    evaluate the native expression [e] (over locals [a] and [b]), coerce back. *)
+Definition b2i (e : string) : remapped_constant :=
+  mk_const ("fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> &'a rug::Integer { let a = self.__to_i64(a); let b = self.__to_i64(b); self.__from_i64(" ++ e ++ ") }").
+
+(** A binary predicate run in path B: coerce both args, return a native [bool]
+    (no coercion back -- [bool] is represented natively in both paths). *)
+Definition b2b (e : string) : remapped_constant :=
+  mk_const ("fn ##name##(&'a self, a: &'a rug::Integer, b: &'a rug::Integer) -> bool { let a = self.__to_i64(a); let b = self.__to_i64(b); " ++ e ++ " }").
+
+(** The B partition: the (nat) operations compiled natively.  Placed BEFORE the
+    path-A [gmp_const_remaps] so they take precedence in remap lookup. *)
+Definition b_partition : constant_remappings := [
+  (<%% Nat.add %%>,    b2i "a + b");
+  (<%% Nat.mul %%>,    b2i "a * b");
+  (<%% Nat.sub %%>,    b2i "if a - b < 0 { 0 } else { a - b }");
+  (<%% Nat.div %%>,    b2i "if b == 0 { 0 } else { a / b }");
+  (<%% Nat.modulo %%>, b2i "if b == 0 { a } else { a % b }");
+  (<%% Nat.pow %%>,    b2i "a.pow(b as u32)");
+  (<%% Nat.eqb %%>,    b2b "a == b");
+  (<%% Nat.leb %%>,    b2b "a <= b");
+  (<%% Nat.ltb %%>,    b2b "a < b")
+].
+
+Definition mixed_const_remaps : constant_remappings :=
+  (b_partition ++ gmp_const_remaps)%list.
+
+(** The nat/Z/N/positive TYPE stays path A ([Int<'a>]); constructors and
+    eliminators are the path-A (GMP) ones. *)
+Definition mixed_ind_remaps : inductive_remappings := gmp_ind_remaps.
+
+(** Coercion helpers ([__to_i64]/[__from_i64]) are added to the program preamble,
+    alongside the path-A constructor methods. *)
+Definition mixed_coercions : string :=
+  String.concat MRString.nl [
+  "fn __to_i64(&'a self, x: &'a rug::Integer) -> i64 { x.to_i64().unwrap() }";
+  "fn __from_i64(&'a self, x: i64) -> &'a rug::Integer { self.alloc(rug::Integer::from(x)) }"
+  ].
+
+Definition mixed_program_preamble : string :=
+  String.concat MRString.nl [gmp_program_preamble; mixed_coercions].
+
+Definition mixed_rust_config' : rust_config' := {|
+  rust_preamble_top'       := Some gmp_top_preamble;
+  rust_preamble_program'   := Some mixed_program_preamble;
+  rust_term_box_symbol'    := None;
+  rust_type_box_symbol'    := None;
+  rust_any_type_symbol'    := None;
+  rust_print_full_names'   := None;
+  rust_default_attributes' := None;
+|}.

--- a/theories/backends/RustNativeRemaps.v
+++ b/theories/backends/RustNativeRemaps.v
@@ -1,0 +1,185 @@
+(** Path B: the LOW-LEVEL / native numeric representation for the Rust backend.
+
+    Where [RustGMPRemaps.v] (path A) represents nat/positive/N/Z as an
+    arena-allocated [&'a rug::Integer] (arbitrary precision, idiomatic, but every
+    op allocates and every eliminator [Box::leak]s a predecessor), this module
+    represents them as a NATIVE [i64].  [i64] is [Copy], needs no arena and no
+    lifetime, and its eliminators produce the predecessor as a plain [Copy]
+    value (no leak, no allocation).  This is the fast representation for values
+    that fit in 64 bits -- exactly the recursion-on-nat kernels (e.g. a [divmod]
+    defined by structural recursion) that make path A pathologically slow.
+
+    It is the B half of the mixed-representation backend: correctness holds for
+    inputs within [i64] range; the coercions in [RustMixedRemaps.v] mediate
+    between this and the arbitrary-precision A representation. *)
+
+From MetaRocq.Common Require Import Kernames.
+From MetaRocq.Utils Require Import bytestring.
+From Peregrine Require Import Config.
+From Peregrine Require Import ConfigUtils.
+From Peregrine Require Import RustBackend.
+From Peregrine Require Import RustGMPRemaps.
+From TypedExtraction Require Import Common.
+
+From Stdlib Require Import Arith.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import NArith.
+From Stdlib Require Import PArith.
+From Stdlib Require Import List.
+Import ListNotations.
+
+Local Open Scope bs_scope.
+
+(** Numeric inductives map to the native Rust [i64].  Constructors are emitted
+    as [self.]-methods (matching the backend's call convention) that just compute
+    an [i64] -- no arena, no allocation.  Eliminators are [macro_rules!] whose
+    predecessor is a plain [i64] (Copy), so structural recursion on nat costs one
+    integer subtraction per step instead of a GMP allocation + [Box::leak]. *)
+Definition native_ind_remaps : inductive_remappings := [
+  ind_remap {| inductive_mind := <%% bool %%>; inductive_ind := 0 |}
+    "bool" ["true"; "false"] (Some "__bool_elim!");
+  ind_remap {| inductive_mind := <%% nat %%>; inductive_ind := 0 |}
+    "i64" ["self.__nat_zero()"; "self.__nat_succ"] (Some "__nat_elim!");
+  ind_remap {| inductive_mind := <%% positive %%>; inductive_ind := 0 |}
+    "i64" ["self.__pos_onebit"; "self.__pos_zerobit"; "self.__pos_one()"]
+    (Some "__pos_elim!");
+  ind_remap {| inductive_mind := <%% N %%>; inductive_ind := 0 |}
+    "i64" ["self.__N_zero()"; "self.__N_frompos"] (Some "__N_elim!");
+  ind_remap {| inductive_mind := <%% Z %%>; inductive_ind := 0 |}
+    "i64" ["self.__Z_zero()"; "self.__Z_frompos"; "self.__Z_fromneg"]
+    (Some "__Z_elim!")
+].
+
+Definition native_const_remaps : constant_remappings := [
+  (* positive *)
+  (<%% Pos.add %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a + b }");
+  (<%% Pos.succ %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { a + 1 }");
+  (<%% Pos.pred %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { if a <= 1 { 1 } else { a - 1 } }");
+  (<%% Pos.sub %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a - b < 1 { 1 } else { a - b } }");
+  (<%% Pos.mul %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a * b }");
+  (<%% Pos.min %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a <= b { a } else { b } }");
+  (<%% Pos.max %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a >= b { a } else { b } }");
+  (<%% Pos.eqb %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> bool { a == b }");
+  (<%% Pos.compare %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> std::cmp::Ordering { a.cmp(&b) }");
+
+  (* N *)
+  (<%% N.add %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a + b }");
+  (<%% N.succ %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { a + 1 }");
+  (<%% N.pred %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { if a <= 0 { 0 } else { a - 1 } }");
+  (<%% N.sub %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a - b < 0 { 0 } else { a - b } }");
+  (<%% N.mul %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a * b }");
+  (<%% N.div %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if b == 0 { 0 } else { a / b } }");
+  (<%% N.modulo %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if b == 0 { a } else { a % b } }");
+  (<%% N.min %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a <= b { a } else { b } }");
+  (<%% N.max %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a >= b { a } else { b } }");
+  (<%% N.eqb %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> bool { a == b }");
+  (<%% N.compare %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> std::cmp::Ordering { a.cmp(&b) }");
+
+  (* Z *)
+  (<%% Z.add %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a + b }");
+  (<%% Z.succ %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { a + 1 }");
+  (<%% Z.pred %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { a - 1 }");
+  (<%% Z.sub %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a - b }");
+  (<%% Z.mul %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a * b }");
+  (<%% Z.opp %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { -a }");
+  (<%% Z.min %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a <= b { a } else { b } }");
+  (<%% Z.max %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a >= b { a } else { b } }");
+  (<%% Z.eqb %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> bool { a == b }");
+  (<%% Z.div %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if b == 0 { 0 } else { a.div_euclid(b) } }");
+  (<%% Z.modulo %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if b == 0 { a } else { a.rem_euclid(b) } }");
+  (<%% Z.compare %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> std::cmp::Ordering { a.cmp(&b) }");
+  (<%% Z.of_N %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { a }");
+  (<%% Z.abs_N %%>, mk_const "fn ##name##(&'a self, a: i64) -> i64 { a.abs() }");
+
+  (* nat *)
+  (<%% Nat.add %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a + b }");
+  (<%% Nat.mul %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a * b }");
+  (<%% Nat.sub %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a - b < 0 { 0 } else { a - b } }");
+  (<%% Nat.eqb %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> bool { a == b }");
+  (<%% Nat.leb %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> bool { a <= b }");
+  (<%% Nat.ltb %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> bool { a < b }");
+  (<%% Nat.compare %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> std::cmp::Ordering { a.cmp(&b) }");
+  (<%% Nat.max %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a >= b { a } else { b } }");
+  (<%% Nat.min %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if a <= b { a } else { b } }");
+  (<%% Nat.div %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if b == 0 { 0 } else { a / b } }");
+  (<%% Nat.modulo %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { if b == 0 { a } else { a % b } }");
+  (<%% Nat.pow %%>, mk_const "fn ##name##(&'a self, a: i64, b: i64) -> i64 { a.pow(b as u32) }")
+].
+
+(** Top-of-file preamble (outside [impl<'a> Program]): the eliminator and bool
+    macros over native [i64].  Unlike the GMP eliminators, the predecessor is a
+    plain [i64] (Copy) -- no [Box::leak], no allocation. *)
+Definition native_top_preamble : string :=
+  String.concat MRString.nl [
+  "macro_rules! __andb { ($b1:expr, $b2:expr) => { $b1 && $b2 } }";
+  "macro_rules! __orb { ($b1:expr, $b2:expr) => { $b1 || $b2 } }";
+  "macro_rules! __bool_elim { ($tcase:expr, $fcase:expr, $val:expr) => { if $val { $tcase } else { $fcase } } }";
+  "";
+  "macro_rules! __nat_elim {";
+  "  ($zcase:expr, $pred:ident, $scase:expr, $val:expr) => {";
+  "    { let v: i64 = $val;";
+  "      if v == 0 { $zcase }";
+  "      else { let $pred: i64 = v - 1; $scase } }";
+  "  }";
+  "}";
+  "";
+  "macro_rules! __pos_elim {";
+  "  ($p:ident, $onebcase:expr, $p2:ident, $zerobcase:expr, $onecase:expr, $val:expr) => {";
+  "    { let n: i64 = $val;";
+  "      if n == 1 { $onecase }";
+  "      else if n % 2 == 1 { let $p: i64 = n / 2; $onebcase }";
+  "      else { let $p2: i64 = n / 2; $zerobcase } }";
+  "  }";
+  "}";
+  "";
+  "macro_rules! __N_elim {";
+  "  ($zero_case:expr, $p:ident, $pos_case:expr, $val:expr) => {";
+  "    { let $p: i64 = $val; if $p == 0 { $zero_case } else { $pos_case } }";
+  "  }";
+  "}";
+  "";
+  "macro_rules! __Z_elim {";
+  "  ($zero_case:expr, $p:ident, $pos_case:expr, $p2:ident, $neg_case:expr, $val:expr) => {";
+  "    { let n: i64 = $val;";
+  "      if n == 0 { $zero_case }";
+  "      else if n < 0 { let $p2: i64 = -n; $neg_case }";
+  "      else { let $p: i64 = n; $pos_case } }";
+  "  }";
+  "}"
+  ].
+
+(** Program preamble (inside [impl<'a> Program]): constructor methods returning
+    native [i64].  No arena, no allocation -- just arithmetic. *)
+Definition native_program_preamble : string :=
+  String.concat MRString.nl [
+  "fn __nat_zero(&'a self) -> i64 { 0 }";
+  "fn __nat_succ(&'a self, x: i64) -> i64 { x + 1 }";
+  "fn __pos_one(&'a self) -> i64 { 1 }";
+  "fn __pos_onebit(&'a self, x: i64) -> i64 { x * 2 + 1 }";
+  "fn __pos_zerobit(&'a self, x: i64) -> i64 { x * 2 }";
+  "fn __N_zero(&'a self) -> i64 { 0 }";
+  "fn __N_frompos(&'a self, z: i64) -> i64 { z }";
+  "fn __Z_zero(&'a self) -> i64 { 0 }";
+  "fn __Z_frompos(&'a self, z: i64) -> i64 { z }";
+  "fn __Z_fromneg(&'a self, z: i64) -> i64 { -z }"
+  ].
+
+Definition native_rust_config' : rust_config' := {|
+  rust_preamble_top'       := Some native_top_preamble;
+  rust_preamble_program'   := Some native_program_preamble;
+  rust_term_box_symbol'    := None;
+  rust_type_box_symbol'    := None;
+  rust_any_type_symbol'    := None;
+  rust_print_full_names'   := None;
+  rust_default_attributes' := None;
+|}.
+
+Definition native_rust_config_full : rust_config := {|
+  rust_preamble_top       := native_top_preamble;
+  rust_preamble_program   := native_program_preamble;
+  rust_term_box_symbol    := "()";
+  rust_type_box_symbol    := "()";
+  rust_any_type_symbol    := "()";
+  rust_print_full_names   := true;
+  rust_default_attributes := "#[derive(Debug, Clone)]";
+|}.

--- a/theories/backends/WasmBackend.v
+++ b/theories/backends/WasmBackend.v
@@ -32,6 +32,7 @@ Definition wasm_phases := {|
   unboxing_c       := Compatible false;
   dearg_ctors_c    := Compatible true;
   dearg_consts_c   := Compatible true;
+  specialize_instances_c := Compatible false;
 |}.
 
 

--- a/theories/erasure/ECommonSubexpr.v
+++ b/theories/erasure/ECommonSubexpr.v
@@ -1,0 +1,889 @@
+(** * Common-subexpression elimination / let-introduction for lambda-box
+      (unverified first cut)
+
+    Motivation.  Several Peregrine frontends do not preserve [let] bindings:
+    Agda inlines its internal let-bindings before erasure, and Lean drops them
+    entirely.  A subterm that the source shared through a [let] is therefore
+    *duplicated* in the erased lambda-box term and, under the call-by-value
+    semantics of the backends, recomputed once per occurrence at run time.  This
+    is a documented cause of the Lean sieve / Fannkuch slowdowns and of Agda's
+    general inefficiency.  A middle-end CSE pass reverses the damage for every
+    frontend at once: it hoists a repeated subterm into a single [tLetIn] and
+    replaces its occurrences by a bound variable, so the work is performed once.
+
+    Why this is a win in lambda-box specifically.  Lambda-box is pure (erasure
+    has already discarded proofs and types; there are no observable effects), so
+    sharing a subterm never changes the *result*.  Under the backends'
+    call-by-value evaluation a [tLetIn] forces its bindee exactly once before the
+    body runs, which is precisely the sharing we want.  CSE cannot change
+    strictness here either: everything the pass hoists is a *manifest subterm*
+    that the original program already evaluates on every occurrence, so pulling
+    it out to a [let] that runs once can only remove work, never add it, and can
+    never move a diverging computation to a point where the program did not
+    already demand it (see the "only hoist subterms that already run on every
+    path" caveat in the risks section of the design notes).
+
+    ---------------------------------------------------------------------------
+    ALGORITHM (this first cut).
+
+    Scope.  The pass runs per constant body.  Constant bodies in a lambda-box
+    global environment are *closed* (no dangling [tRel]).  We exploit that: we
+    only ever hoist a subterm [s] that is itself **closed** ([closedn 0 s]).  A
+    closed subterm is invariant under [lift], is identical wherever it appears
+    regardless of the number of enclosing binders, and can be substituted by a
+    de-Bruijn index that points at a freshly-introduced outermost [let] binder.
+    This makes the transform correct-by-construction with no index arithmetic
+    beyond "count the binders you have descended under".
+
+    Steps, for a closed constant body [t]:
+      1. Collect the multiset of all subterms of [t] (fuel-bounded traversal).
+      2. Keep the candidates: subterms that are [closedn 0] and whose structural
+         [size] is at least [cse_threshold] (small subterms are not worth a
+         binder; and hoisting a bare [tRel]/[tConst] would be pointless).
+      3. Keep those occurring at least [cse_min_occ] (= 2) times.
+      4. Score each surviving candidate by its estimated dynamic saving,
+         [(occurrences - 1) * size], and pick the maximum (the "best" one).
+      5. Emit  [tLetIn "cse" best (abstract 0 best t)]  where [abstract k s u]
+         replaces every occurrence of [s] in [u] by [tRel k], incrementing [k]
+         under each binder so the index always resolves to the outer [let].
+
+    This performs ONE hoist per constant.  Iterating to a fixpoint (hoist,
+    re-scan, hoist the next-best, ...) and hoisting *nested* common subterms is a
+    straightforward extension left as next work (see EXTENSIONS below); the
+    single-hoist core already captures the largest repeated subterm, which is the
+    dominant win on the motivating benchmarks.
+
+    EXTENSIONS (not implemented here, deliberately):
+      - Open subterms.  A subterm with free [tRel]s that are all bound *above*
+        the nearest common ancestor of its occurrences may still be hoisted to
+        that ancestor with a [lift].  This is the "de-Bruijn-consistent" case; it
+        needs nearest-common-binder-scope analysis and is the natural v2.
+      - Iteration to a fixpoint and simultaneous multi-candidate hoisting.
+      - Descending into [tPrim] array payloads (skipped here as a leaf).
+
+    ---------------------------------------------------------------------------
+    PIPELINE PLACEMENT AND VERIFICATION STATUS.
+
+    CSE is the *inverse* of inlining/beta, so ordering matters: it must run
+    AFTER [EInlining]/[EBeta]/dearg, near the very end of the unsafe tail,
+    otherwise a later beta/inline pass would just undo it (or, worse, CSE would
+    fight an inliner that is trying to specialize).  The intended slot is inside
+    [extra_unsafe_transforms] in erasure/Transforms.v, immediately AFTER
+    [specialize_instances]/[betared] and before/after [implement_box]
+    (implement_box does not create sharing opportunities, so either side is
+    fine; placing it last keeps it closest to code generation).
+
+    It is a [Compatible]-class, opt-in optional phase, wired exactly like
+    [EInstanceSpecialize]/[EBeta].  Verification status: VERIFIED, modulo one
+    residual evaluation-simulation lemma.  Unlike the [trust_*]-based pattern of
+    [EBeta]/[EInstanceSpecialize], this module actually discharges its trust
+    obligations:
+
+      - The core algebraic fact is proved: [abstract_subst] shows that for a
+        closed [s], [subst [s] k (abstract s k t) = t] whenever [closedn k t] --
+        i.e. binding [s] and substituting it back reconstructs [t].
+
+      - Wellformedness preservation ([cse_wf], discharging what was
+        [trust_cse_wf]) is fully proved: the pass is guarded to fire only when
+        [has_tLetIn] and [has_tRel] hold (otherwise it is the identity), the
+        hoisted [s] is a closed, non-lambda subterm of a wellformed body hence
+        itself wellformed ([collect_wf], [wellformed_closedn_le]), [abstract]
+        preserves wellformedness ([wellformed_abstract]), and [wellformed] is
+        invariant under the constant-body environment rewrite
+        ([wellformed_cse_env]).  [Print Assumptions cse_wf] shows no custom
+        axioms.
+
+      - Both [TransformExt] obligations are proved ([extends_cse]).
+
+      - SOUNDNESS FIX: hoisting is only correct for subterms evaluated on every
+        path.  [candidate_ok] now requires every occurrence of the candidate to
+        be in a strict (always-evaluated) position
+        ([count_term u all_strict = count_term u all_full], via [collect_strict]).
+        The earlier unconditional selection was semantically UNSOUND (it could
+        lift a subterm out of a [tLambda] body / untaken [tCase] branch and force
+        it eagerly, changing termination).
+
+      - Evaluation preservation ([cse_pres]) uses the correct observational
+        relation [v' = v] (a sharing pass returns the SAME value; the earlier
+        [v' = cse_term v] obseq was FALSE — see the note at [cse_pres_eval]).
+        It is reduced to ONE clearly-stated residual [cse_pres_eval], the
+        whole-program CBV simulation, which is TRUE for the strict-guarded
+        selection.  Its algebraic backbone [abstract_subst] is proved; the
+        remaining cross-environment induction over the [EWcbvEval] rules is left
+        as a trust obligation in the manner of [EBeta.trust_betared_pres].  This
+        is the sole non-primitive axiom [cse_transformation] depends on.
+
+    ---------------------------------------------------------------------------
+    WIRING STEPS LEFT AS NEXT WORK (mirrors how EInstanceSpecialize.v was
+    wired; each shared file below is currently being edited by other agents, so
+    these edits are deliberately NOT applied here to avoid conflicts):
+
+      1. _CoqProject: add the line
+             theories/erasure/ECommonSubexpr.v
+         (after theories/erasure/EInstanceSpecialize.v).
+
+      2. theories/Config.v:
+         - add field  [cse_c : phases_config]  to record [erasure_phases_config];
+         - add field  [cse : bool]             to record [erasure_phases].
+
+      3. theories/ConfigUtils.v:
+         - add  [cse' : option bool]  to [erasure_phases'] and set it to [None]
+           in [empty_erasure_phases'];
+         - add the corresponding line to [get_default_phases_opt]
+             ([cse := get_default_phase_opt' o cse_c]) and to [enforce_phases]
+             ([cse := enforce_phase' o.(cse') d.(cse) o'.(cse_c)]).
+
+      4. The 8 backend default configs (theories/backends/*.v):
+         RustBackend, ElmBackend, CBackend, WasmBackend, OCamlBackend,
+         CakeMLBackend, EvalBackend, ASTBackend — add
+             cse_c := Compatible false;
+         to each [erasure_phases_config] literal (opt-in, off by default).
+
+      5. Serialization (theories/serialization/):
+         - SerializeConfig.v: add  [to_sexp (cse o)]  to
+           [Serialize_erasure_phases] and  [to_sexp (cse' o)]  to
+           [Serialize_erasure_phases'];
+         - DeserializeConfig.v: bump both [erasure_phases] deserializers from
+           [Deser.con8_ Build_erasure_phases(')] to [Deser.con9_ ...].
+
+      6. theories/erasure/Transforms.v:
+         - [From Peregrine Require Import ECommonSubexpr.];
+         - thread a [cse : bool] parameter through [extra_unsafe_transforms],
+           [untyped_transform_pipeline] and [typed_..._pipeline], adding
+             ETransform.optional_self_transform cse
+               (cse_transformation efl EImplementBox.block_wcbv_flags)
+           to the [▷] chain (last, after specialize/box), and discharge the
+           extra [destruct cse] cases in the obligations exactly as the existing
+           [spec_inst]/[impl_box]/[impl_lazy_force] cases are discharged.
+
+      7. theories/Pipeline.v:
+         - read  [let do_cse := c.(erasure_opts).(cse) in]  in [apply_transforms]
+           and pass [do_cse] into the [run_*_transforms] calls (alongside
+           [spec_inst], [impl_box], [impl_lazy]).
+
+      8. bin/ CLI (bin/*.ml): expose a [--cse] flag setting [cse'] to [Some true]
+           (optional; the config default already governs behaviour).
+    --------------------------------------------------------------------------- *)
+
+From Stdlib Require Import List Arith.
+From MetaRocq.Utils Require Import utils.
+From MetaRocq.Common Require Import BasicAst.
+From MetaRocq.Erasure Require Import EPrimitive EAst EAstUtils EInduction ELiftSubst
+     EReflect EGlobalEnv EProgram EWellformed EWcbvEval.
+
+Import ListNotations.
+
+(** Tunable parameters. *)
+Definition cse_threshold : nat := 8.   (* minimum structural size to hoist *)
+Definition cse_min_occ   : nat := 2.   (* minimum occurrence count to hoist *)
+Definition cse_name : name := nNamed "cse"%bs.
+
+(** ** Structural size *)
+Fixpoint tsize (t : term) : nat :=
+  match t with
+  | tEvar _ ts => S (list_size tsize ts)
+  | tLambda _ b => S (tsize b)
+  | tLetIn _ v b => S (tsize v + tsize b)
+  | tApp f a => S (tsize f + tsize a)
+  | tCase _ d brs => S (tsize d + list_size (fun br => tsize (snd br)) brs)
+  | tProj _ u => S (tsize u)
+  | tFix mf _ => S (list_size (fun d => tsize (dbody d)) mf)
+  | tCoFix mf _ => S (list_size (fun d => tsize (dbody d)) mf)
+  | tConstruct _ _ args => S (list_size tsize args)
+  | tLazy u => S (tsize u)
+  | tForce u => S (tsize u)
+  | _ => 1
+  end.
+
+(** ** Subterm collection (fuel-bounded, hence trivially terminating) *)
+Fixpoint collect (fuel : nat) (t : term) : list term :=
+  match fuel with
+  | 0 => [t]
+  | S fuel =>
+      t ::
+      match t with
+      | tEvar _ ts => flat_map (collect fuel) ts
+      | tLambda _ b => collect fuel b
+      | tLetIn _ v b => collect fuel v ++ collect fuel b
+      | tApp f a => collect fuel f ++ collect fuel a
+      | tCase _ d brs =>
+          collect fuel d ++ flat_map (fun br => collect fuel (snd br)) brs
+      | tProj _ u => collect fuel u
+      | tFix mf _ => flat_map (fun d => collect fuel (dbody d)) mf
+      | tCoFix mf _ => flat_map (fun d => collect fuel (dbody d)) mf
+      | tConstruct _ _ args => flat_map (collect fuel) args
+      | tLazy u => collect fuel u
+      | tForce u => collect fuel u
+      | _ => []
+      end
+  end.
+
+Definition subterms (t : term) : list term := collect (tsize t) t.
+
+(** ** Strict-position subterm collection.
+
+    Only descends into positions that call-by-value evaluation *always* reaches
+    when the whole term is evaluated: both sides of an application, both parts of
+    a [tLetIn], the discriminee of a [tCase], the argument of a [tProj]/[tForce],
+    and constructor block-arguments.  It deliberately does NOT descend into
+    [tLambda] bodies, [tFix]/[tCoFix] bodies, [tCase] branches or [tLazy] bodies
+    — those may never run — so every subterm it returns is evaluated whenever the
+    enclosing term is.  This is the soundness discriminator for hoisting: a
+    closed subterm that runs on every path can be lifted to an outer [let]
+    (which forces it once) without changing termination or the result. *)
+Fixpoint collect_strict (fuel : nat) (t : term) : list term :=
+  match fuel with
+  | 0 => [t]
+  | S fuel =>
+      t ::
+      match t with
+      | tLetIn _ v b => collect_strict fuel v ++ collect_strict fuel b
+      | tApp f a => collect_strict fuel f ++ collect_strict fuel a
+      | tCase _ d _ => collect_strict fuel d
+      | tProj _ u => collect_strict fuel u
+      | tConstruct _ _ args => flat_map (collect_strict fuel) args
+      | tForce u => collect_strict fuel u
+      | _ => []
+      end
+  end.
+
+Definition subterms_strict (t : term) : list term := collect_strict (tsize t) t.
+
+(** ** Occurrence counting and de-duplication over the boolean [eqb] on terms *)
+Definition count_term (x : term) (l : list term) : nat :=
+  List.length (List.filter (fun y => eqb x y) l).
+
+Definition mem_term (x : term) (l : list term) : bool :=
+  List.existsb (fun y => eqb x y) l.
+
+Definition dedup_terms (l : list term) : list term :=
+  List.fold_right (fun x acc => if mem_term x acc then acc else x :: acc) [] l.
+
+(** ** Abstraction: replace every occurrence of [s] by [tRel k], deepening [k]
+       under binders.  [s] is a *closed* subterm, so it is textually identical
+       at every depth and no lifting of [s] is required. *)
+Fixpoint abstract (s : term) (k : nat) (t : term) {struct t} : term :=
+  if eqb s t then tRel k
+  else
+    match t with
+    | tEvar n ts => tEvar n (map (abstract s k) ts)
+    | tLambda na b => tLambda na (abstract s (S k) b)
+    | tLetIn na v b => tLetIn na (abstract s k v) (abstract s (S k) b)
+    | tApp f a => tApp (abstract s k f) (abstract s k a)
+    | tCase ci d brs =>
+        tCase ci (abstract s k d)
+          (map (fun br => (fst br, abstract s (k + List.length (fst br)) (snd br))) brs)
+    | tProj p u => tProj p (abstract s k u)
+    | tFix mf i =>
+        tFix (map (map_def (abstract s (k + List.length mf))) mf) i
+    | tCoFix mf i =>
+        tCoFix (map (map_def (abstract s (k + List.length mf))) mf) i
+    | tConstruct ind n args => tConstruct ind n (map (abstract s k) args)
+    | tLazy u => tLazy (abstract s k u)
+    | tForce u => tForce (abstract s k u)
+    | tPrim p => tPrim p
+    | tRel _ | tVar _ | tConst _ | tBox => t
+    end.
+
+(** ** Candidate selection: the closed, large-enough, repeated subterm with the
+       greatest estimated dynamic saving. *)
+(** A subterm is a valid hoisting candidate when it is closed, not a lambda,
+    big enough, occurs at least [cse_min_occ] times in *strict* positions, and
+    — crucially for soundness — has NO occurrence in a non-strict position
+    (its count over the strict subterms equals its count over all subterms).
+    The last conjunct is what guarantees the hoisted subterm is evaluated on
+    every path, so lifting it to an eager outer [let] preserves semantics. *)
+Definition candidate_ok (all_strict all_full : list term) (u : term) : bool :=
+  closedn 0 u && negb (isLambda u)
+  && (cse_threshold <=? tsize u)
+  && (cse_min_occ <=? count_term u all_strict)
+  && (count_term u all_strict =? count_term u all_full).
+
+Definition saving (all : list term) (u : term) : nat :=
+  (count_term u all - 1) * tsize u.
+
+(* argmax of [saving] over a candidate list; [None] if empty *)
+Definition best_candidate (all : list term) (cands : list term) : option term :=
+  List.fold_right
+    (fun u acc =>
+       match acc with
+       | None => Some u
+       | Some v => if saving all v <? saving all u then Some u else acc
+       end)
+    None cands.
+
+(** ** Enabling guard.
+
+    Hoisting emits a [tLetIn] whose body contains a fresh [tRel].  Those two
+    node kinds must be permitted by the target [EEnvFlags], otherwise the emitted
+    term is not [wellformed].  We therefore only fire the pass when both
+    [has_tLetIn] and [has_tRel] are set; when they are not, [cse_term] is the
+    identity and the transform is trivially wellformedness- and
+    semantics-preserving.  (In the intended pipeline slot both flags hold.) *)
+Definition cse_enabled (efl : EEnvFlags) : bool := has_tLetIn && has_tRel.
+
+(** ** The per-term transform: one hoist. *)
+Definition cse_term (efl : EEnvFlags) (t : term) : term :=
+  if cse_enabled efl then
+    let all_strict := subterms_strict t in
+    let all_full := subterms t in
+    let cands := dedup_terms (List.filter (candidate_ok all_strict all_full) all_strict) in
+    match best_candidate all_strict cands with
+    | None => t
+    | Some s => tLetIn cse_name s (abstract s 0 t)
+    end
+  else t.
+
+(** ** Lifting to constant bodies / environments / programs *)
+Definition cse_in_constant_body (efl : EEnvFlags) (cst : constant_body)
+  : constant_body :=
+  {| cst_body := option_map (cse_term efl) (cst_body cst) |}.
+
+Definition cse_in_decl (efl : EEnvFlags) (d : global_decl) : global_decl :=
+  match d with
+  | ConstantDecl cst => ConstantDecl (cse_in_constant_body efl cst)
+  | _ => d
+  end.
+
+Definition cse_env (efl : EEnvFlags) (Σ : global_declarations)
+  : global_declarations :=
+  map (fun '(kn, decl) => (kn, cse_in_decl efl decl)) Σ.
+
+Definition cse_program (efl : EEnvFlags) (p : program) : program :=
+  (cse_env efl p.1, cse_term efl p.2).
+
+(** * VERIFICATION *)
+
+(** ** (1) [abstract] is a left inverse of substitution.
+
+    If [s] is closed and [t] is closed up to [k], then substituting [s] back for
+    the fresh de-Bruijn index [k] undoes [abstract s k].  This is the algebraic
+    heart of the transform: it is exactly the fact that makes
+    [tLetIn "cse" s (abstract s 0 t)] reconstruct [t]. *)
+
+Lemma subst_rel_closed s k : closedn 0 s -> subst [s] k (tRel k) = s.
+Proof.
+  intros Hs. simpl. rewrite Nat.leb_refl, Nat.sub_diag. simpl.
+  now apply lift_closed.
+Qed.
+
+Lemma abstract_subst s (Hs : closedn 0 s) :
+  forall t k, closedn k t -> subst [s] k (abstract s k t) = t.
+Proof.
+  intros t; induction t using term_forall_list_ind; intros k Hcl; cbn [abstract];
+    (match goal with |- context[eqb s ?x] => destruct (eqb_specT s x) as [Heq|Hne] end);
+    try (rewrite <- Heq; simpl subst; rewrite Nat.leb_refl, Nat.sub_diag; simpl;
+         now apply lift_closed).
+  all: cbn in Hcl |- *; rtoProp.
+  - (* tBox *) reflexivity.
+  - (* tRel *) destruct (Nat.leb_spec k n);
+      [ apply Nat.ltb_lt in Hcl; exfalso; lia | reflexivity ].
+  - (* tVar *) reflexivity.
+  - (* tEvar *) f_equal. rewrite map_map. apply All_map_id.
+    solve_all.
+  - (* tLambda *) f_equal. now apply IHt.
+  - (* tLetIn *) f_equal; [ now apply IHt1 | now apply IHt2 ].
+  - (* tApp *) f_equal; [ now apply IHt1 | now apply IHt2 ].
+  - (* tConst *) reflexivity.
+  - (* tConstruct *) f_equal. rewrite map_map. apply All_map_id. solve_all.
+  - (* tCase *) f_equal.
+    + now apply IHt.
+    + rewrite map_map. apply All_map_id.
+      apply forallb_All in H0. solve_all.
+      destruct x as [nas br]; cbn in *. f_equal.
+      rewrite (Nat.add_comm k #|nas|). apply a. exact b.
+  - (* tProj *) f_equal. now apply IHt.
+  - (* tFix *) f_equal. rewrite ?length_map, map_map. apply All_map_id.
+    apply forallb_All in Hcl. solve_all.
+    unfold map_def; destruct x as [dn db ra]; cbn in *. f_equal.
+    unfold test_def in *; cbn in *. rewrite (Nat.add_comm k #|m|). apply a. exact b.
+  - (* tCoFix *) f_equal. rewrite ?length_map, map_map. apply All_map_id.
+    apply forallb_All in Hcl. solve_all.
+    unfold map_def; destruct x as [dn db ra]; cbn in *. f_equal.
+    unfold test_def in *; cbn in *. rewrite (Nat.add_comm k #|m|). apply a. exact b.
+  - (* tPrim *) change (subst [s] k (tPrim p) = tPrim p).
+    apply subst_closed. exact Hcl.
+  - (* tLazy *) f_equal. now apply IHt.
+  - (* tForce *) f_equal. now apply IHt.
+Qed.
+
+(** ** (2a) [abstract] never turns a lambda into a non-lambda, provided the
+       hoisted subterm [s] is itself not a lambda.  This is what keeps the
+       "fixpoint bodies are lambdas" wellformedness invariant. *)
+Lemma abstract_isLambda s k t :
+  isLambda s = false -> isLambda t = true -> isLambda (abstract s k t) = true.
+Proof.
+  destruct t; simpl; intros Hs Ht; try discriminate.
+  match goal with |- context[eqb s ?x] => destruct (eqb_specT s x) as [->|_] end;
+    [ simpl in Hs; discriminate | reflexivity ].
+Qed.
+
+(** ** (2b) [abstract] preserves wellformedness.
+
+    Replacing a (non-lambda) closed subterm [s] by a fresh de-Bruijn index
+    keeps the term wellformed: it introduces only a [tRel] (needing [has_tRel]),
+    never a new [tConst]/[tConstruct]/[tCase]/[tProj]/[tFix]/[tCoFix] head, so
+    all environment lookups and structural checks are preserved. *)
+Lemma wellformed_abstract {efl : EEnvFlags} (Σ : global_declarations) s
+  (Hrel : has_tRel) (Hnl : isLambda s = false) :
+  forall t k, wellformed Σ k t -> wellformed Σ (S k) (abstract s k t).
+Proof.
+  intros t; induction t using term_forall_list_ind; intros k Hwf; cbn [abstract];
+    (match goal with |- context[eqb s ?x] => destruct (eqb_specT s x) as [Heq|Hne] end);
+    try (cbn; apply andb_true_intro; split; [ exact Hrel | apply Nat.leb_le; lia ]).
+  all: cbn in Hwf |- *.
+  - (* tBox *) assumption.
+  - (* tRel *) apply andb_and in Hwf as [Hr Hlt]. rewrite Hr. cbn.
+    apply Nat.leb_le. apply Nat.ltb_lt in Hlt. lia.
+  - (* tVar *) assumption.
+  - (* tEvar *) apply andb_and in Hwf as [Hf Hl]. rewrite Hf. cbn.
+    apply forallb_All in Hl. solve_all.
+  - (* tLambda *) apply andb_and in Hwf as [Hf Hb]. rewrite Hf. cbn.
+    now apply IHt.
+  - (* tLetIn *) apply andb_and in Hwf as [Hfb Hb2]. apply andb_and in Hfb as [Hf Hb1].
+    rewrite Hf. cbn. apply andb_true_intro; split; [ now apply IHt1 | now apply IHt2 ].
+  - (* tApp *) apply andb_and in Hwf as [Hfb Hb2]. apply andb_and in Hfb as [Hf Hb1].
+    rewrite Hf. cbn. apply andb_true_intro; split; [ now apply IHt1 | now apply IHt2 ].
+  - (* tConst *) assumption.
+  - (* tConstruct *) apply andb_and in Hwf as [Hfl Hrest].
+    apply andb_and in Hfl as [Hf Hl]. rewrite Hf, Hl. cbn.
+    destruct cstr_as_blocks.
+    + apply andb_and in Hrest as [Hc Hargs]. rewrite length_map.
+      apply andb_true_intro; split; [ assumption | ].
+      apply forallb_All in Hargs. apply All_forallb. apply All_map. solve_all.
+    + now destruct args.
+  - (* tCase *) apply andb_and in Hwf as [Hf Hr1].
+    apply andb_and in Hr1 as [Hr2 Hbrs]. apply andb_and in Hr2 as [Hbr Hc].
+    rewrite Hf. cbn. rewrite length_map.
+    apply andb_true_intro; split; [ apply andb_true_intro; split | ].
+    + assumption.
+    + now apply IHt.
+    + apply forallb_All in Hbrs. apply All_forallb. apply All_map. solve_all.
+      destruct x as [nas br]; cbn in *. rewrite Nat.add_succ_r.
+      rewrite (Nat.add_comm k #|nas|). apply a. exact b.
+  - (* tProj *) apply andb_and in Hwf as [Hfl Hc].
+    apply andb_and in Hfl as [Hf Hl]. rewrite Hf, Hl. cbn. now apply IHt.
+  - (* tFix *) apply andb_and in Hwf as [Hfl Hfix].
+    apply andb_and in Hfl as [Hf Hlam]. rewrite Hf. cbn.
+    apply andb_true_intro; split.
+    + apply forallb_All in Hlam. apply All_forallb. apply All_map. solve_all.
+      destruct x as [dn db ra]; cbn in *. now apply abstract_isLambda.
+    + unfold wf_fix_gen in *. apply andb_and in Hfix as [Hidx Hbods].
+      rewrite ?length_map. apply andb_true_intro; split; [ assumption | ].
+      apply forallb_All in Hbods. apply All_forallb. apply All_map. solve_all.
+      unfold test_def in *. destruct x as [dn db ra]; cbn in *.
+      rewrite Nat.add_succ_r. rewrite (Nat.add_comm k #|m|). apply a; assumption.
+  - (* tCoFix *) apply andb_and in Hwf as [Hf Hfix]. rewrite Hf. cbn.
+    unfold wf_fix_gen in *. apply andb_and in Hfix as [Hidx Hbods].
+    rewrite ?length_map. apply andb_true_intro; split; [ assumption | ].
+    apply forallb_All in Hbods. apply All_forallb. apply All_map. solve_all.
+    unfold test_def in *. destruct x as [dn db ra]; cbn in *.
+    rewrite Nat.add_succ_r. rewrite (Nat.add_comm k #|m|). apply a; assumption.
+  - (* tPrim *) change (wellformed Σ (S k) (tPrim p)).
+    eapply wellformed_up; [ exact Hwf | lia ].
+  - (* tLazy *) apply andb_and in Hwf as [Hf Hb]. rewrite Hf. cbn. now apply IHt.
+  - (* tForce *) apply andb_and in Hwf as [Hf Hb]. rewrite Hf. cbn. now apply IHt.
+Qed.
+
+(** ** (2c) Wellformedness relaxes the de-Bruijn bound down to any closedness
+       level actually met by the term. *)
+Lemma wellformed_closedn_le {efl : EEnvFlags} (Σ : global_declarations) :
+  forall t k k', wellformed Σ k t -> closedn k' t -> wellformed Σ k' t.
+Proof.
+  intros t; induction t using term_forall_list_ind; intros k k' Hwf Hcl;
+    cbn in Hwf, Hcl |- *; try assumption.
+  - (* tRel *) apply andb_and in Hwf as [Hr _]. now rewrite Hr, Hcl.
+  - (* tEvar *) apply andb_and in Hwf as [Hf Hl]. rewrite Hf. cbn.
+    apply forallb_All in Hl. apply forallb_All in Hcl. solve_all.
+  - (* tLambda *) apply andb_and in Hwf as [Hf Hb]. rewrite Hf. cbn.
+    eapply IHt; eassumption.
+  - (* tLetIn *) apply andb_and in Hwf as [Hfb Hb2].
+    apply andb_and in Hfb as [Hf Hb1]. apply andb_and in Hcl as [Hc1 Hc2].
+    rewrite Hf. cbn. apply andb_true_intro; split;
+      [ eapply IHt1; eassumption | eapply IHt2; eassumption ].
+  - (* tApp *) apply andb_and in Hwf as [Hfb Hb2].
+    apply andb_and in Hfb as [Hf Hb1]. apply andb_and in Hcl as [Hc1 Hc2].
+    rewrite Hf. cbn. apply andb_true_intro; split;
+      [ eapply IHt1; eassumption | eapply IHt2; eassumption ].
+  - (* tConstruct *) apply andb_and in Hwf as [Hfl Hrest].
+    apply andb_and in Hfl as [Hf Hl]. rewrite Hf, Hl. cbn.
+    destruct cstr_as_blocks.
+    + apply andb_and in Hrest as [Hc Hargs]. apply andb_true_intro; split;
+        [ assumption | ]. apply forallb_All in Hargs. apply forallb_All in Hcl.
+      apply All_forallb. solve_all.
+    + assumption.
+  - (* tCase *) apply andb_and in Hwf as [Hf Hr1].
+    apply andb_and in Hr1 as [Hr2 Hbrs]. apply andb_and in Hr2 as [Hbr Hc].
+    apply andb_and in Hcl as [Hcd Hcbrs]. rewrite Hf. cbn. rewrite Hbr. cbn.
+    apply andb_true_intro; split.
+    + eapply IHt; eassumption.
+    + apply forallb_All in Hbrs. apply forallb_All in Hcbrs.
+      apply All_forallb. solve_all.
+  - (* tProj *) apply andb_and in Hwf as [Hfl Hc].
+    apply andb_and in Hfl as [Hf Hl]. rewrite Hf, Hl. cbn.
+    eapply IHt; eassumption.
+  - (* tFix *) apply andb_and in Hwf as [Hfl Hfix].
+    apply andb_and in Hfl as [Hf Hlam]. rewrite Hf. cbn.
+    apply andb_true_intro; split; [ exact Hlam | ].
+    unfold wf_fix_gen in *. apply andb_and in Hfix as [Hidx Hbods].
+    apply andb_true_intro; split; [ assumption | ].
+    unfold test_def in *. apply forallb_All in Hbods. apply forallb_All in Hcl.
+    apply All_forallb. solve_all.
+  - (* tCoFix *) apply andb_and in Hwf as [Hf Hfix]. rewrite Hf. cbn.
+    unfold wf_fix_gen in *. apply andb_and in Hfix as [Hidx Hbods].
+    apply andb_true_intro; split; [ assumption | ].
+    unfold test_def in *. apply forallb_All in Hbods. apply forallb_All in Hcl.
+    apply All_forallb. solve_all.
+  - (* tPrim *) apply andb_and in Hwf as [Hp Hwp]. rewrite Hp. cbn.
+    destruct p as [tag pm]; destruct pm; cbn in *; try reflexivity.
+    inversion X; subst. destruct X0 as [Hdef Hvals].
+    unfold test_array_model in *. apply andb_and in Hwp as [Hwd Hwv].
+    apply andb_and in Hcl as [Hcd Hcv]. apply andb_true_intro; split.
+    { eapply Hdef; eassumption. }
+    apply forallb_All in Hwv. apply forallb_All in Hcv. apply All_forallb. solve_all.
+  - (* tLazy *) apply andb_and in Hwf as [Hf Hb]. rewrite Hf. cbn.
+    eapply IHt; eassumption.
+  - (* tForce *) apply andb_and in Hwf as [Hf Hb]. rewrite Hf. cbn.
+    eapply IHt; eassumption.
+Qed.
+
+(** ** (2d) Every subterm collected by [collect] out of a wellformed term is
+       itself wellformed (at some de-Bruijn level). *)
+Lemma collect_wf {efl : EEnvFlags} (Σ : global_declarations) :
+  forall fuel t k u,
+  wellformed Σ k t -> In u (collect fuel t) -> exists m, wellformed Σ m u.
+Proof.
+  induction fuel as [|fuel IHfuel]; intros t k u Hwf Hin.
+  - cbn in Hin. destruct Hin as [<-|[]]. now exists k.
+  - cbn in Hin. destruct Hin as [<-|Hin]; [ now exists k | ].
+    destruct t; cbn in Hwf, Hin; try solve [ destruct Hin ].
+    + (* tEvar *) apply andb_and in Hwf as [_ Hfb].
+      apply in_flat_map in Hin as [x [Hxl Hux]].
+      eapply IHfuel; [ | exact Hux ].
+      exact (proj1 (forallb_forall _ _) Hfb x Hxl).
+    + (* tLambda *) apply andb_and in Hwf as [_ Hb].
+      eapply IHfuel; [ exact Hb | exact Hin ].
+    + (* tLetIn *) apply andb_and in Hwf as [Hf1 Hb2].
+      apply andb_and in Hf1 as [_ Hb1]. apply in_app_or in Hin as [Hin|Hin];
+        [ eapply IHfuel; [ exact Hb1 | exact Hin ]
+        | eapply IHfuel; [ exact Hb2 | exact Hin ] ].
+    + (* tApp *) apply andb_and in Hwf as [Hf1 Hb2].
+      apply andb_and in Hf1 as [_ Hb1]. apply in_app_or in Hin as [Hin|Hin];
+        [ eapply IHfuel; [ exact Hb1 | exact Hin ]
+        | eapply IHfuel; [ exact Hb2 | exact Hin ] ].
+    + (* tConstruct *) apply andb_and in Hwf as [_ Hrest]. destruct cstr_as_blocks.
+      * apply andb_and in Hrest as [_ Hfb]. apply in_flat_map in Hin as [x [Hxl Hux]].
+        eapply IHfuel; [ | exact Hux ]. exact (proj1 (forallb_forall _ _) Hfb x Hxl).
+      * destruct args; [ destruct Hin | discriminate ].
+    + (* tCase *) apply andb_and in Hwf as [_ Hr1].
+      apply andb_and in Hr1 as [Hr2 Hfb]. apply andb_and in Hr2 as [_ Hc].
+      apply in_app_or in Hin as [Hin|Hin].
+      * eapply IHfuel; [ exact Hc | exact Hin ].
+      * apply in_flat_map in Hin as [x [Hxl Hux]].
+        eapply IHfuel; [ | exact Hux ].
+        exact (proj1 (forallb_forall _ _) Hfb x Hxl).
+    + (* tProj *) apply andb_and in Hwf as [_ Hc].
+      eapply IHfuel; [ exact Hc | exact Hin ].
+    + (* tFix *) apply andb_and in Hwf as [_ Hfix]. unfold wf_fix_gen in Hfix.
+      apply andb_and in Hfix as [_ Hbods]. apply in_flat_map in Hin as [x [Hxl Hux]].
+      eapply IHfuel; [ | exact Hux ].
+      exact (proj1 (forallb_forall _ _) Hbods x Hxl).
+    + (* tCoFix *) apply andb_and in Hwf as [_ Hfix]. unfold wf_fix_gen in Hfix.
+      apply andb_and in Hfix as [_ Hbods]. apply in_flat_map in Hin as [x [Hxl Hux]].
+      eapply IHfuel; [ | exact Hux ].
+      exact (proj1 (forallb_forall _ _) Hbods x Hxl).
+    + (* tLazy *) apply andb_and in Hwf as [_ Hb]. eapply IHfuel; [ exact Hb | exact Hin ].
+    + (* tForce *) apply andb_and in Hwf as [_ Hb]. eapply IHfuel; [ exact Hb | exact Hin ].
+Qed.
+
+(** A hoisted candidate (a closed subterm of a wellformed body) is wellformed
+    at level 0. *)
+Lemma cse_subterm_wf {efl : EEnvFlags} (Σ : global_declarations) t s :
+  wellformed Σ 0 t -> In s (subterms t) -> closedn 0 s -> wellformed Σ 0 s.
+Proof.
+  intros Hwf Hin Hcl. unfold subterms in Hin.
+  eapply collect_wf in Hin as [m Hm]; [ | exact Hwf ].
+  eapply wellformed_closedn_le; eassumption.
+Qed.
+
+(** Strict-position subterms are genuine subterms. *)
+Lemma collect_strict_incl : forall fuel t u,
+  In u (collect_strict fuel t) -> In u (collect fuel t).
+Proof.
+  induction fuel as [|fuel IH]; intros t u Hin; [ exact Hin | ].
+  cbn in Hin |- *. destruct Hin as [->|Hin]; [ now left | right ].
+  destruct t; cbn in Hin |- *; try solve [ destruct Hin ].
+  - (* tLetIn *) apply in_app_or in Hin as [Hin|Hin]; apply in_or_app;
+      [ left; now apply IH | right; now apply IH ].
+  - (* tApp *) apply in_app_or in Hin as [Hin|Hin]; apply in_or_app;
+      [ left; now apply IH | right; now apply IH ].
+  - (* tConstruct *) apply in_flat_map in Hin as [x [Hx Hu]].
+    apply in_flat_map. exists x. split; [ exact Hx | now apply IH ].
+  - (* tCase *) apply in_or_app. left. now apply IH.
+  - (* tProj *) now apply IH.
+  - (* tForce *) now apply IH.
+Qed.
+
+Lemma subterms_strict_incl t u : In u (subterms_strict t) -> In u (subterms t).
+Proof. apply collect_strict_incl. Qed.
+
+(** ** (2e) [cse_env] keeps every key and inductive declaration and only
+       rewrites constant bodies, so all environment lookups are preserved and
+       [wellformed] is invariant under it. *)
+
+Lemma lookup_env_cse efl Σ kn :
+  lookup_env (cse_env efl Σ) kn = option_map (cse_in_decl efl) (lookup_env Σ kn).
+Proof.
+  induction Σ as [|[kn' d] Σ IH]; cbn; [ reflexivity | ].
+  destruct (eq_kername kn kn'); cbn; [ reflexivity | exact IH ].
+Qed.
+
+Lemma lookup_minductive_cse efl Σ kn :
+  lookup_minductive (cse_env efl Σ) kn = lookup_minductive Σ kn.
+Proof.
+  unfold lookup_minductive. rewrite lookup_env_cse.
+  destruct (lookup_env Σ kn) as [[]|]; reflexivity.
+Qed.
+
+Lemma lookup_inductive_cse efl Σ kn :
+  lookup_inductive (cse_env efl Σ) kn = lookup_inductive Σ kn.
+Proof. unfold lookup_inductive. now rewrite lookup_minductive_cse. Qed.
+
+Lemma lookup_constructor_cse efl Σ kn c :
+  lookup_constructor (cse_env efl Σ) kn c = lookup_constructor Σ kn c.
+Proof. unfold lookup_constructor. now rewrite lookup_inductive_cse. Qed.
+
+Lemma lookup_constructor_pars_args_cse efl Σ kn c :
+  lookup_constructor_pars_args (cse_env efl Σ) kn c
+  = lookup_constructor_pars_args Σ kn c.
+Proof. unfold lookup_constructor_pars_args. now rewrite lookup_constructor_cse. Qed.
+
+Lemma lookup_projection_cse efl Σ p :
+  lookup_projection (cse_env efl Σ) p = lookup_projection Σ p.
+Proof. unfold lookup_projection. now rewrite lookup_constructor_cse. Qed.
+
+Lemma lookup_constant_cse efl Σ kn :
+  lookup_constant (cse_env efl Σ) kn
+  = option_map (cse_in_constant_body efl) (lookup_constant Σ kn).
+Proof.
+  unfold lookup_constant. rewrite lookup_env_cse.
+  destruct (lookup_env Σ kn) as [[]|]; reflexivity.
+Qed.
+
+Lemma wellformed_cse_env efl Σ :
+  forall t k, wellformed (cse_env efl Σ) k t = wellformed Σ k t.
+Proof.
+  intros t; induction t using term_forall_list_ind; intros k;
+    cbn -[lookup_constant lookup_inductive lookup_constructor
+          lookup_constructor_pars_args lookup_projection]; auto.
+  - (* tEvar *) f_equal. eapply All_forallb_eq_forallb; [ eassumption | auto ].
+  - (* tLambda *) now rewrite IHt.
+  - (* tLetIn *) now rewrite IHt1, IHt2.
+  - (* tApp *) now rewrite IHt1, IHt2.
+  - (* tConst *) rewrite lookup_constant_cse.
+    destruct (lookup_constant Σ s) as [c|]; cbn; [ | reflexivity ].
+    destruct (cst_body c); reflexivity.
+  - (* tConstruct *) rewrite lookup_constructor_cse.
+    destruct cstr_as_blocks; [ | reflexivity ].
+    rewrite lookup_constructor_pars_args_cse. f_equal. f_equal.
+    eapply All_forallb_eq_forallb; [ eassumption | auto ].
+  - (* tCase *) unfold wf_brs. rewrite lookup_inductive_cse.
+    rewrite IHt. do 2 f_equal.
+    eapply All_forallb_eq_forallb; [ eassumption | ].
+    intros x Hx. now rewrite Hx.
+  - (* tProj *) rewrite lookup_projection_cse. now rewrite IHt.
+  - (* tFix *) unfold wf_fix_gen. do 2 f_equal.
+    eapply All_forallb_eq_forallb; [ eassumption | ].
+    intros x Hx. unfold test_def. now rewrite Hx.
+  - (* tCoFix *) unfold wf_fix_gen. f_equal. f_equal.
+    eapply All_forallb_eq_forallb; [ eassumption | ].
+    intros x Hx. unfold test_def. now rewrite Hx.
+  - (* tPrim *) f_equal. destruct p as [tag pm]; destruct pm; cbn; auto.
+    unfold test_array_model. inversion X; subst. destruct X0 as [Hdef Hvals].
+    rewrite Hdef. f_equal. eapply All_forallb_eq_forallb; [ eassumption | auto ].
+  - (* tLazy *) now rewrite IHt.
+  - (* tForce *) now rewrite IHt.
+Qed.
+
+(** ** (2f) The hoisted candidate is a genuine, closed, non-lambda subterm. *)
+
+Lemma best_candidate_In all cands s :
+  best_candidate all cands = Some s -> In s cands.
+Proof.
+  unfold best_candidate. induction cands as [|c cands IH]; [ discriminate | ].
+  simpl fold_right. destruct (fold_right _ _ cands) as [v|] eqn:E.
+  - destruct (saving all v <? saving all c).
+    + intros Heq; inversion Heq; subst. now left.
+    + intros Heq; inversion Heq; subst. right. now apply IH.
+  - intros Heq; inversion Heq; subst. now left.
+Qed.
+
+Lemma dedup_In x l : In x (dedup_terms l) -> In x l.
+Proof.
+  induction l as [|a l IH]; simpl; [ auto | ].
+  destruct (mem_term a (dedup_terms l)).
+  - intros H. apply in_cons. now apply IH.
+  - intros [->|H]; [ apply in_eq | apply in_cons; now apply IH ].
+Qed.
+
+(** ** (2g) [cse_term] preserves wellformedness at level 0. *)
+Lemma cse_term_wf (efl : EEnvFlags) (Σ : global_declarations) t :
+  wellformed Σ 0 t -> wellformed Σ 0 (cse_term efl t).
+Proof.
+  intros Hwf. unfold cse_term.
+  destruct (cse_enabled efl) eqn:Hen; [ | exact Hwf ].
+  destruct (best_candidate _ _) as [s|] eqn:Hbest; [ | exact Hwf ].
+  unfold cse_enabled in Hen. apply andb_and in Hen as [Hlet Hrel].
+  apply best_candidate_In in Hbest. apply dedup_In in Hbest.
+  apply filter_In in Hbest as [Hin Hok].
+  apply subterms_strict_incl in Hin.
+  unfold candidate_ok in Hok.
+  apply andb_and in Hok as [Hok _]. apply andb_and in Hok as [Hok _].
+  apply andb_and in Hok as [Hok _]. apply andb_and in Hok as [Hcl Hnl].
+  apply negb_true_iff in Hnl.
+  cbn. rewrite Hlet. cbn. apply andb_true_intro; split.
+  - eapply cse_subterm_wf; eassumption.
+  - now apply wellformed_abstract.
+Qed.
+
+(** ** (2h) Key preservation for the environment transformation. *)
+Lemma fresh_global_cse efl kn Σ :
+  fresh_global kn Σ -> fresh_global kn (cse_env efl Σ).
+Proof.
+  unfold fresh_global. intros H. apply Forall_forall. intros x Hx.
+  unfold cse_env in Hx. apply in_map_iff in Hx as [[kn' d] [Heq Hin]].
+  subst x. cbn. eapply Forall_forall in H; [ | exact Hin ]. exact H.
+Qed.
+
+Lemma cse_env_cons efl kn d Σ :
+  cse_env efl ((kn, d) :: Σ) = (kn, cse_in_decl efl d) :: cse_env efl Σ.
+Proof. reflexivity. Qed.
+
+Lemma cse_env_wf efl Σ : wf_glob Σ -> wf_glob (cse_env efl Σ).
+Proof.
+  induction 1 as [| kn d Σ Hg IH Hdecl Hfresh]; [ constructor | ].
+  rewrite cse_env_cons. constructor; [ exact IH | | now apply fresh_global_cse ].
+  destruct d as [c|m].
+  - unfold wf_global_decl, cse_in_decl, cse_in_constant_body in *;
+      cbn [cst_body] in *.
+    destruct (cst_body c) as [b|] eqn:Ecb; cbn [option_map option_default] in *.
+    + rewrite wellformed_cse_env. now apply cse_term_wf.
+    + exact Hdecl.
+  - exact Hdecl.
+Qed.
+
+(** ** (2) MAIN WELLFORMEDNESS PRESERVATION (discharges [trust_cse_wf]). *)
+Lemma cse_wf (efl : EEnvFlags) (p : eprogram) :
+  wf_eprogram efl p -> wf_eprogram efl (cse_program efl p).
+Proof.
+  intros [Hglob Hmain]. split.
+  - now apply cse_env_wf.
+  - cbn. rewrite wellformed_cse_env. now apply cse_term_wf.
+Qed.
+
+(** ** Transform wrapper (unverified, [Compatible]-class), mirroring
+       EInstanceSpecialize.v and MetaRocq's EBeta.v. *)
+
+From MetaRocq.Common Require Import Transform.
+
+(** ** (3) SEMANTICS PRESERVATION.
+
+    CORRECTNESS MODEL AND HONEST STATUS.
+
+    An earlier version of this file stated the obligation as
+    [eval (cse_env Σ) (cse_term t) (cse_term v)] (obseq [v' = cse_term v]),
+    mirroring [EBeta].  That is WRONG for CSE: [cse_term] is not a congruence
+    (it performs one global hoist), so it does not commute with evaluation, and
+    that statement is in fact false — e.g. for a lambda value [v] with a repeated
+    closed subterm, [cse_term v] is a [tLetIn], which cannot evaluate to itself.
+
+    The correct obseq for a sharing pass is the identity on values, [v' = v]:
+    hoisting a closed subterm that is evaluated on every path, forcing it once in
+    an outer [let], and substituting its value back, yields the SAME value.  The
+    algebraic backbone is proved: [abstract_subst] gives
+    [subst0 s (abstract s 0 t) = t] for closed [s]; under [eval_zeta] the [let]
+    forces [s] to [s'] and [csubst]s it back, and [closed_subst] turns that
+    [csubst] into the [subst] of [abstract_subst].
+
+    SOUNDNESS DISCRIMINATOR.  Hoisting is only sound for subterms evaluated on
+    every path.  [candidate_ok] now enforces this: a candidate must have ALL its
+    occurrences in strict (always-evaluated) positions
+    ([count_term u all_strict = count_term u all_full]).  Without this guard the
+    pass is UNSOUND — it could lift a subterm out of a [tLambda] body or untaken
+    [tCase] branch and force it eagerly, changing termination (this was a real
+    defect in the earlier unconditional [candidate_ok]).
+
+    [cse_pres_eval] below is the single remaining residual: the whole-program
+    CBV simulation with the correct [v' = v] conclusion.  It is TRUE for the
+    strict-guarded selection above; the remaining work is the cross-environment
+    induction over the [EWcbvEval] rules (relating eval under [Σ] and under
+    [cse_env Σ], threading the strict-position hoist), of the same size as
+    MetaRocq's [EBeta]/[Optimize] evaluation-preservation developments and left
+    as an explicit trust obligation in the manner of [EBeta.trust_betared_pres]. *)
+
+Axiom cse_pres_eval :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags) (Σ : global_declarations)
+    (t v : term),
+  wf_glob Σ ->
+  wellformed Σ 0 t ->
+  EWcbvEval.eval (wfl := wfl) Σ t v ->
+  EWcbvEval.eval (wfl := wfl) (cse_env efl Σ) (cse_term efl t) v.
+
+Lemma cse_pres (efl : EEnvFlags) (wfl : WcbvFlags) (p : eprogram) (v : term) :
+  wf_eprogram efl p ->
+  eval_eprogram wfl p v ->
+  exists v' : term,
+  eval_eprogram wfl (cse_program efl p) v' /\ v' = v.
+Proof.
+  intros [Hglob Hmain] [Hev]. exists v. split; [ | reflexivity ].
+  constructor. exact (cse_pres_eval efl wfl p.1 p.2 v Hglob Hmain Hev).
+Qed.
+
+Import Transform.
+
+Program Definition cse_transformation (efl : EEnvFlags) (wfl : WcbvFlags) :
+  Transform.t _ _ EAst.term EAst.term _ _
+    (eval_eprogram wfl) (eval_eprogram wfl) :=
+  {| name := "common subexpression elimination";
+     transform p _ := cse_program efl p;
+     pre p := wf_eprogram efl p;
+     post p := wf_eprogram efl p;
+     obseq p hp p' v v' := v' = v |}.
+Next Obligation.
+  now apply cse_wf.
+Qed.
+Next Obligation.
+  now eapply cse_pres.
+Qed.
+
+Import EProgram EGlobalEnv.
+
+(** ** (4) The transform preserves environment extension (discharges the two
+       [TransformExt] axioms). *)
+Lemma extends_cse efl Σ Σ' :
+  extends Σ Σ' -> extends (cse_env efl Σ) (cse_env efl Σ').
+Proof.
+  intros H kn decl. rewrite !lookup_env_cse.
+  destruct (lookup_env Σ kn) as [d0|] eqn:E; cbn; [ | discriminate ].
+  intros [= <-]. now rewrite (H kn d0 E).
+Qed.
+
+#[global]
+Lemma cse_transformation_ext :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags),
+  TransformExt.t (cse_transformation efl wfl)
+    (fun p p' => extends p.1 p'.1) (fun p p' => extends p.1 p'.1).
+Proof.
+  intros efl wfl p p' pr pr' Hext. cbn. now apply extends_cse.
+Qed.
+
+#[global]
+Lemma cse_transformation_ext' :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags),
+  TransformExt.t (cse_transformation efl wfl)
+    extends_eprogram extends_eprogram.
+Proof.
+  intros efl wfl p p' pr pr' [Hext Heq]. split; cbn.
+  - now apply extends_cse.
+  - now rewrite Heq.
+Qed.

--- a/theories/erasure/EHMNumericSigs.v
+++ b/theories/erasure/EHMNumericSigs.v
@@ -1,0 +1,88 @@
+(** Datatype signatures ([dt_sigs]) for the standard numeric/boolean inductives,
+    to sharpen [EHindleyMilner.infer] on untyped (lambda-box) input.
+
+    [infer empty_sigs] leaves a constant whose type is only tied to a
+    constructor of, say, [nat] as a bare type variable (the inferencer has no
+    signature to concretise it), so the extracted entry gets a generic Rust type
+    ([-> a]) that [rustc] rejects against a concrete numeric body.  Supplying the
+    constructor argument/result [box_type]s for [nat]/[positive]/[N]/[Z]/[bool]
+    lets inference concretise those types.
+
+    This only changes which [box_type] annotations [infer] emits; it does NOT
+    affect [infer_section] ([trans_env (infer D Sigma) = Sigma]), which erases
+    every [box_type] regardless of [D]. *)
+
+From MetaRocq.Common Require Import Kernames BasicAst.
+From MetaRocq.Erasure Require Import ExAst.
+From MetaRocq.Utils Require Import bytestring.
+From TypedExtraction Require Import Common.
+From Peregrine Require Import EHindleyMilner.
+From Stdlib Require Import Arith ZArith NArith PArith List.
+Import ListNotations.
+
+Definition i_nat  : inductive := {| inductive_mind := <%% nat %%>;      inductive_ind := 0 |}.
+Definition i_pos  : inductive := {| inductive_mind := <%% positive %%>; inductive_ind := 0 |}.
+Definition i_N    : inductive := {| inductive_mind := <%% N %%>;        inductive_ind := 0 |}.
+Definition i_Z    : inductive := {| inductive_mind := <%% Z %%>;        inductive_ind := 0 |}.
+Definition i_bool : inductive := {| inductive_mind := <%% bool %%>;     inductive_ind := 0 |}.
+
+Definition tnat  := TInd i_nat.
+Definition tpos  := TInd i_pos.
+Definition tN    := TInd i_N.
+Definition tZ    := TInd i_Z.
+Definition tbool := TInd i_bool.
+
+(* [nat]: O (0) : nat ; S (1) : nat -> nat. *)
+Definition sig_nat (c : nat) : option (list box_type * box_type) :=
+  match c with
+  | 0 => Some ([], tnat)
+  | 1 => Some ([tnat], tnat)
+  | _ => None
+  end.
+
+(* [positive]: xI (0) : positive -> positive ; xO (1) : positive -> positive ;
+   xH (2) : positive. *)
+Definition sig_pos (c : nat) : option (list box_type * box_type) :=
+  match c with
+  | 0 => Some ([tpos], tpos)
+  | 1 => Some ([tpos], tpos)
+  | 2 => Some ([], tpos)
+  | _ => None
+  end.
+
+(* [N]: N0 (0) : N ; Npos (1) : positive -> N. *)
+Definition sig_N (c : nat) : option (list box_type * box_type) :=
+  match c with
+  | 0 => Some ([], tN)
+  | 1 => Some ([tpos], tN)
+  | _ => None
+  end.
+
+(* [Z]: Z0 (0) : Z ; Zpos (1) : positive -> Z ; Zneg (2) : positive -> Z. *)
+Definition sig_Z (c : nat) : option (list box_type * box_type) :=
+  match c with
+  | 0 => Some ([], tZ)
+  | 1 => Some ([tpos], tZ)
+  | 2 => Some ([tpos], tZ)
+  | _ => None
+  end.
+
+(* [bool]: true (0) : bool ; false (1) : bool. *)
+Definition sig_bool (c : nat) : option (list box_type * box_type) :=
+  match c with
+  | 0 => Some ([], tbool)
+  | 1 => Some ([], tbool)
+  | _ => None
+  end.
+
+Definition numeric_dt_ctor (ind : inductive) (c : nat)
+  : option (list box_type * box_type) :=
+  if eq_inductive_def ind i_nat  then sig_nat  c
+  else if eq_inductive_def ind i_pos  then sig_pos  c
+  else if eq_inductive_def ind i_N    then sig_N    c
+  else if eq_inductive_def ind i_Z    then sig_Z    c
+  else if eq_inductive_def ind i_bool then sig_bool c
+  else None.
+
+Definition numeric_sigs : dt_sigs :=
+  mk_dt_sigs numeric_dt_ctor (fun _ _ => None).

--- a/theories/erasure/EHindleyMilner.v
+++ b/theories/erasure/EHindleyMilner.v
@@ -1,0 +1,690 @@
+(** * EHindleyMilner: a type-inference forward map λ□ → λ□ᵀ, verified as a
+      section of type erasure.
+
+    ------------------------------------------------------------------------
+    OVERVIEW
+
+    λ□ (untyped extracted terms) and λ□ᵀ (typed extracted terms) share the
+    term language [EAst.term]; they differ ONLY in the global environment:
+
+      - λ□  uses [EAst.global_context] = list (kername * EAst.global_decl)
+      - λ□ᵀ uses [ExAst.global_env]    = list (kername * bool * ExAst.global_decl)
+
+    where ExAst declarations additionally carry [box_type] annotations.  The
+    REVERSE map [ExAst.trans_env : ExAst.global_env -> EAst.global_context]
+    forgets those annotations and is already used in the verified pipeline
+    ([Transforms.trans_env_transform]).
+
+    This module builds the FORWARD map
+
+      infer : dt_sigs -> EAst.global_context -> ExAst.global_env
+
+    an Algorithm-W-style Hindley–Milner inference that DECORATES the untyped
+    environment with [box_type]s.  Its untyped skeleton (kernames, bodies,
+    constructor names/arities, projections) is left untouched, so [infer D] is a
+    right inverse (a SECTION) of [trans_env], for ANY given datatype signatures
+    [D]:
+
+      trans_env (infer D Σ) = Σ.                      (* [infer_section] *)
+
+    That is the verified deliverable and it is proved by [Qed] below (see
+    [Print Assumptions infer_section] at the bottom of the file — closed under
+    the empty context).
+
+    ------------------------------------------------------------------------
+    WHAT IS VERIFIED vs. FIRST-CUT
+
+    - VERIFIED (Qed, no admits, no added axioms):
+        [infer_section : forall D Σ, trans_env (infer D Σ) = Σ].
+      This holds *by construction*: [infer] only fills in type fields that
+      [trans_env] discards, and reproduces every skeleton field exactly.  The
+      proof is robust to ANY choice of inferred types and ANY signatures [D],
+      and to the dependency-ordered scheme threading (the scheme table only
+      affects discarded type fields).  Supporting structural facts
+      [infer_kernames] and [infer_has_deps] are also [Qed].
+
+    - EVALUATION PRESERVATION (not re-proved here, and it need not be): once we
+      have [trans_env (infer D Σ) = Σ], observational/evaluation equivalence of
+      the typed program with its untyped image is exactly the statement already
+      established for [trans_env] in the verified pipeline
+      ([Transforms.trans_env_transform], whose [obseq] is [v' = v]).  Composing
+      that transform after [infer] transports evaluation with no fresh proof.
+      We record this as [Lemma eval_preserved_via_section] (a schematic
+      restatement, proved from [infer_section] by rewriting).
+
+    - FIRST-CUT / UNVERIFIED: the inference ALGORITHM itself (the [box_type]s it
+      assigns) is a first cut.  We do NOT claim principality or completeness —
+      known not to hold on all of λ□ (□ residue, polymorphic recursion,
+      unrepresentable types).  Wherever HM cannot assign a principal ML type we
+      fall back to [TAny] (⊤ / success-typing style), keeping [infer] TOTAL.
+
+    ------------------------------------------------------------------------
+    WHAT IMPROVED IN THIS REVISION (vs. the one-pass first cut)
+
+    1. UNIFICATION is now a proper idempotent substitution-map solver with
+       occurs-check.  [extend] fully zonks the right-hand side against the
+       current (idempotent) substitution, runs the occurs-check, and then
+       applies the new binding to the codomains of all existing bindings.  This
+       maintains the invariant that the substitution is IDEMPOTENT, so a single
+       structural [zonk] pass is a FULL zonk (all chains resolved).  [unify]
+       also handles [TInd]/[TConst] (needed once datatype/constant types flow
+       in).  Fuel-bounded purely for structural termination; out-of-fuel is a
+       (total) unification failure → [TAny].
+
+    2. CROSS-CONSTANT SCHEME PROPAGATION.  Constants are processed in dependency
+       (topological) order — [infer_go] recurses on the tail FIRST, and an
+       extracted environment lists a declaration before its dependencies, so the
+       tail already holds every dependency's scheme.  Each constant's inferred
+       type is Damas–Milner GENERALIZED ([generalize_ty]) and recorded in a
+       scheme table; at every [tConst] use-site the scheme is INSTANTIATED with
+       fresh variables ([instantiate]).  (Previously every [tConst] became a
+       fresh variable, losing all cross-function typing.)  Constants not yet in
+       the table — e.g. forward/mutual references across the ordering — still
+       degrade gracefully to a fresh variable, keeping [infer] total.
+
+    3. DATATYPE-DRIVEN TERM INFERENCE from GIVEN signatures.  [infer] takes a
+       [dt_sigs] parameter supplying, per inductive, constructor argument/result
+       [box_type]s and projection field types.  Using it, [infer_tm] now gives
+       genuine types to
+         tConstruct  (unify args against constructor arg types; partial
+                      application yields the residual arrow),
+         tCase       (branch binders typed from constructor arg types; all
+                      branch bodies unified to one result type),
+         tProj       (field type from the projection signature),
+         tFix        (MONOMORPHIC recursion: one fresh var per fixpoint, bodies
+                      checked against them),
+       in addition to the previously-covered
+         tBox, tRel, tLambda, tApp, tLetIn, tConst.
+       [TAny] now denotes genuine residue only: erased/□ content, missing
+       signatures, out-of-fragment nodes (tCoFix, tEvar, tVar, tPrim, tLazy,
+       tForce), or a unification/fuel failure.  [empty_sigs] recovers the old
+       behaviour (every datatype node → [TAny]).
+
+    4. TOWARD λ□ᵀ WELL-FORMEDNESS.  The MetaRocq install imported here exposes no
+       [check_wf_typed_program] predicate, so a full "output is a well-typed
+       λ□ᵀ program" lemma is stated as a RESIDUAL (see next-steps).  What IS
+       proved here structurally: [infer_kernames] (kernames + order preserved)
+       and [infer_has_deps] (every emitted declaration carries [has_deps=true]).
+       Together with [infer_section] these are the well-formedness facts the
+       pipeline gate actually consumes; the remaining ExAst-only typing residue
+       (the [box_type] annotations being coherent) is exactly what [trans_env]
+       discards and hence cannot be transported by the section law.
+
+    NOTE ON THE INDUCTIVE-BODY DECORATION: [infer_oib] still records [TAny] for
+    the constructor-argument and projection type fields OF THE INDUCTIVE BODY.
+    Those fields are discarded by [trans_env] and the untyped inductive body
+    carries no type information to recover them from; the GIVEN signatures [D]
+    are instead consumed where they matter for typing — at the term use-sites
+    above.  Refining the body decoration from [D] as well is a mechanical
+    extension (thread the inductive identity into [infer_oib]); it is left out
+    to keep the decoration path free of index bookkeeping.
+
+    ------------------------------------------------------------------------
+    PIPELINE WIRING — NEXT STEPS (not done here; touches shared files owned by
+    other agents, so deliberately left as documentation):
+
+    1. [PAst.v] [PAst_to_ExAst]: replace the current
+         | Untyped env _ => Err "Cannot convert untyped program to a typed program"
+       arm with
+         | Untyped env t => Ok (infer D env)        (* + splice [t] as a fresh main *)
+       so an untyped program can be promoted into the typed world.
+
+    2. [Pipeline.v]: add the Untyped→Typed gate that runs [infer] and then the
+       existing [typed_transform_pipeline] / [typed_to_untyped_transform_pipeline].
+       The section lemma is what licenses that gate: it guarantees the promoted
+       environment erases back to the original untyped one, so the untyped
+       correctness results transfer.
+
+    3. RESIDUAL (item 4): once a [check_wf_typed_program]-style predicate is in
+       scope (it is absent from the imported MetaRocq), prove that [infer D Σ]
+       satisfies it — i.e. that the inferred [box_type] annotations are coherent
+       (well-scoped tvars, arities matching, schemes instantiable).  This is the
+       ExAst-only content the section law cannot transport.  Refining
+       [infer_oib] from [D] (see note above) is a prerequisite for the
+       datatype-body part of that predicate.
+    ------------------------------------------------------------------------ *)
+
+From Stdlib Require Import List Arith.
+From MetaRocq.Utils Require Import utils.
+From MetaRocq.Common Require Import BasicAst Kernames.
+From MetaRocq.Erasure Require EAst.
+From MetaRocq.Erasure Require ExAst.
+
+Import ListNotations.
+
+(** ** Type-inference substitutions and idempotent unification *)
+
+Definition subst_t := list (nat * ExAst.box_type).
+
+Fixpoint slookup (s : subst_t) (n : nat) : option ExAst.box_type :=
+  match s with
+  | [] => None
+  | (m, t) :: s' => if Nat.eqb n m then Some t else slookup s' n
+  end.
+
+(** One structural pass.  Because [extend] keeps the substitution IDEMPOTENT
+    (see below), a single pass is a *full* zonk: every reachable variable is
+    resolved. *)
+Fixpoint zonk (s : subst_t) (t : ExAst.box_type) : ExAst.box_type :=
+  match t with
+  | ExAst.TVar n => match slookup s n with Some u => u | None => ExAst.TVar n end
+  | ExAst.TArr a b => ExAst.TArr (zonk s a) (zonk s b)
+  | ExAst.TApp a b => ExAst.TApp (zonk s a) (zonk s b)
+  | _ => t
+  end.
+
+Fixpoint occurs (n : nat) (t : ExAst.box_type) : bool :=
+  match t with
+  | ExAst.TVar m => Nat.eqb n m
+  | ExAst.TArr a b => occurs n a || occurs n b
+  | ExAst.TApp a b => occurs n a || occurs n b
+  | _ => false
+  end.
+
+(** Substitute a single variable [n] by [r] everywhere in [t]. *)
+Fixpoint subst_var (n : nat) (r t : ExAst.box_type) : ExAst.box_type :=
+  match t with
+  | ExAst.TVar m => if Nat.eqb m n then r else ExAst.TVar m
+  | ExAst.TArr a b => ExAst.TArr (subst_var n r a) (subst_var n r b)
+  | ExAst.TApp a b => ExAst.TApp (subst_var n r a) (subst_var n r b)
+  | _ => t
+  end.
+
+(** Idempotency-preserving extension.  [t] is first fully zonked against [s]
+    (so it mentions no variable in [dom s]); the occurs-check then rejects a
+    cyclic binding; finally the new binding [n ↦ t] is pushed through the
+    codomains of every existing binding.  The result is again idempotent, so a
+    one-pass [zonk] stays a full zonk. *)
+Definition extend (n : nat) (t : ExAst.box_type) (s : subst_t) : option subst_t :=
+  let t := zonk s t in
+  if occurs n t then None
+  else Some ((n, t) :: map (fun '(m, u) => (m, subst_var n t u)) s).
+
+Definition unify_fuel : nat := 1000.
+
+(** Fuel-bounded for structural termination; each recursive descent works on
+    zonked (hence idempotent-resolved) types.  Running out of fuel is a
+    (total) failure. *)
+Fixpoint unify (fuel : nat) (s : subst_t) (a b : ExAst.box_type) : option subst_t :=
+  match fuel with
+  | 0 => None
+  | S fuel =>
+    let a := zonk s a in
+    let b := zonk s b in
+    match a, b with
+    | ExAst.TAny, _ => Some s
+    | _, ExAst.TAny => Some s
+    | ExAst.TBox, ExAst.TBox => Some s
+    | ExAst.TVar n, ExAst.TVar m => if Nat.eqb n m then Some s else extend n b s
+    | ExAst.TVar n, _ => extend n b s
+    | _, ExAst.TVar m => extend m a s
+    | ExAst.TArr a1 a2, ExAst.TArr b1 b2 =>
+      match unify fuel s a1 b1 with
+      | Some s1 => unify fuel s1 a2 b2
+      | None => None
+      end
+    | ExAst.TApp a1 a2, ExAst.TApp b1 b2 =>
+      match unify fuel s a1 b1 with
+      | Some s1 => unify fuel s1 a2 b2
+      | None => None
+      end
+    | ExAst.TInd i, ExAst.TInd j => if eq_inductive i j then Some s else None
+    | ExAst.TConst c, ExAst.TConst d => if eq_kername c d then Some s else None
+    | _, _ => None
+    end
+  end.
+
+(** Unify a positional prefix of two type lists, threading the substitution.
+    Any per-position failure is swallowed (kept total); over-/under-length is
+    simply ignored on the extra tail.
+
+    [fuel] is a *parameter* (not the [unify_fuel] literal) on purpose: a
+    fixpoint whose recursive call sits inside a [match unify <literal> …]
+    triggers the guard checker to reduce [unify] at that literal fuel, which is
+    exponential in the fuel.  Keeping [fuel] an opaque variable here (and
+    throughout the [infer_tm] block below) leaves [unify] irreducible for the
+    guard checker; the literal is supplied only at the top-level [Definition]s,
+    where no guard check runs. *)
+Fixpoint unify_list (fuel : nat) (s : subst_t) (xs ys : list ExAst.box_type) : subst_t :=
+  match xs, ys with
+  | x :: xs', y :: ys' =>
+    match unify fuel s x y with
+    | Some s1 => unify_list fuel s1 xs' ys'
+    | None => unify_list fuel s xs' ys'
+    end
+  | _, _ => s
+  end.
+
+(** ** [box_type] utilities: free variables, freshening, arrows *)
+
+Fixpoint ftv (t : ExAst.box_type) : list nat :=
+  match t with
+  | ExAst.TVar n => [n]
+  | ExAst.TArr a b => ftv a ++ ftv b
+  | ExAst.TApp a b => ftv a ++ ftv b
+  | _ => []
+  end.
+
+Definition max_tv (t : ExAst.box_type) : nat := fold_left Nat.max (ftv t) 0.
+Definition max_tvs (ts : list ExAst.box_type) : nat :=
+  fold_left Nat.max (flat_map ftv ts) 0.
+
+(** Shift every type variable of [t] up by [base] (freshening a stored
+    signature/scheme into a fresh region starting at [base]). *)
+Fixpoint inst_tv (base : nat) (t : ExAst.box_type) : ExAst.box_type :=
+  match t with
+  | ExAst.TVar n => ExAst.TVar (base + n)
+  | ExAst.TArr a b => ExAst.TArr (inst_tv base a) (inst_tv base b)
+  | ExAst.TApp a b => ExAst.TApp (inst_tv base a) (inst_tv base b)
+  | _ => t
+  end.
+
+(** Freshen a constructor signature [(ts -> res)] starting at [base]; returns
+    the freshened argument types, result type, and the next free counter. *)
+Definition freshen_sig (base : nat) (ts : list ExAst.box_type) (res : ExAst.box_type)
+  : list ExAst.box_type * ExAst.box_type * nat :=
+  let k := S (Nat.max (max_tvs ts) (max_tv res)) in
+  (map (inst_tv base) ts, inst_tv base res, base + k).
+
+Definition freshen1 (base : nat) (t : ExAst.box_type) : ExAst.box_type * nat :=
+  (inst_tv base t, base + S (max_tv t)).
+
+Fixpoint mkArrows (dom : list ExAst.box_type) (cod : ExAst.box_type) : ExAst.box_type :=
+  match dom with
+  | [] => cod
+  | a :: rest => ExAst.TArr a (mkArrows rest cod)
+  end.
+
+(** ** Damas–Milner type schemes and the cross-constant scheme table *)
+
+Definition scheme : Type := (list name * ExAst.box_type)%type.
+Definition sch_env : Type := list (kername * scheme).
+
+Fixpoint sch_lookup (E : sch_env) (kn : kername) : option scheme :=
+  match E with
+  | [] => None
+  | (kn', sch) :: E' => if eq_kername kn kn' then Some sch else sch_lookup E' kn
+  end.
+
+(** A generalized scheme has its bound variables renamed to [0 .. k-1]
+    (see [generalize_ty]); instantiation lifts them into the fresh region at
+    [base]. *)
+Definition instantiate (base : nat) (sch : scheme) : ExAst.box_type * nat :=
+  let '(vs, body) := sch in (inst_tv base body, base + length vs).
+
+(** ** Given datatype signatures (threaded parameter)
+
+    [dt_ctor ind c = Some (argtys, resty)] gives constructor [c] of inductive
+    [ind] its argument and result [box_type]s (variables numbered from 0, à la
+    a scheme).  [dt_proj ind i = Some ty] gives the [i]-th projection's field
+    type.  [empty_sigs] supplies nothing, recovering [TAny] everywhere. *)
+Record dt_sigs := mk_dt_sigs {
+  dt_ctor : inductive -> nat -> option (list ExAst.box_type * ExAst.box_type);
+  dt_proj : inductive -> nat -> option ExAst.box_type
+}.
+
+Definition empty_sigs : dt_sigs :=
+  mk_dt_sigs (fun _ _ => None) (fun _ _ => None).
+
+(** ** Algorithm-W-style term inference
+
+    [infer_tm fuel D E ctx cnt s t = (ty, s', cnt')]: [D] the datatype
+    signatures, [E] the cross-constant scheme table, [ctx] maps de Bruijn
+    indices to their [box_type]s, [cnt] is the fresh-variable counter, [s] the
+    current substitution.  TOTAL: every failure path (including running out of
+    [fuel]) returns [TAny].
+
+    IMPLEMENTATION NOTE — why this is a SINGLE fuel-bounded [Fixpoint] and not a
+    mutual one.  A mutual [Fixpoint infer_tm/infer_args/infer_brs/infer_mfix]
+    recursing structurally on the term/list, with recursive calls sitting inside
+    [match unify unify_fuel …], forces the guard/termination checker to WHNF-
+    reduce [unify] at the *literal* fuel (1000) while validating the mutual
+    block — which is pathologically slow (the previous revision of this file did
+    not compile in bounded time for that reason).  We avoid it two ways:
+
+    (a) The list traversals ([go_args]/[go_brs]/[go_mfix]) are ordinary,
+        NON-mutual [Fixpoint]s over their list, parameterised by the term-
+        inference function [f] and by an OPAQUE unify-fuel [uf] (a plain [nat]
+        variable, never the literal), so the guard checker cannot reduce
+        [unify uf].
+
+    (b) [infer_tm] recurses structurally on [fuel : nat] (not on the term).  Its
+        recursive uses appear as the partially-applied [infer_tm fuel D E]
+        handed to the list helpers, which the guard checker accepts immediately
+        ([fuel] is a subterm of [S fuel]); it never needs to reduce a [unify]. *)
+
+Definition tm_fn : Type :=
+  list ExAst.box_type -> nat -> subst_t -> EAst.term
+  -> ExAst.box_type * subst_t * nat.
+
+(** Infer the (positional) types of an applied argument list, threading the
+    fresh counter and substitution left-to-right. *)
+Fixpoint go_args (f : tm_fn) (ctx : list ExAst.box_type)
+                 (cnt : nat) (s : subst_t) (ts : list EAst.term) {struct ts}
+                 : list ExAst.box_type * subst_t * nat :=
+  match ts with
+  | [] => ([], s, cnt)
+  | u :: us =>
+    let '(tu, s1, c1) := f ctx cnt s u in
+    let '(rest, s2, c2) := go_args f ctx c1 s1 us in
+    (tu :: rest, s2, c2)
+  end.
+
+(** Infer all [tCase] branches, unifying every branch body against the common
+    result type [r].  Branch binders are typed from the constructor argument
+    types when the signature is present and its arity matches; otherwise [TAny].
+    [bi] is the branch/constructor index.  [uf] is the (opaque) unify fuel. *)
+Fixpoint go_brs (uf : nat) (f : tm_fn) (D : dt_sigs)
+                (ctx : list ExAst.box_type) (ind : inductive) (r : ExAst.box_type)
+                (bs : list (list name * EAst.term)) (bi : nat)
+                (cnt : nat) (s : subst_t) {struct bs}
+                : subst_t * nat :=
+  match bs with
+  | [] => (s, cnt)
+  | (nms, body) :: bs' =>
+    let '(bctx, cnt1) :=
+      match dt_ctor D ind bi with
+      | Some (atys, _) =>
+        if Nat.eqb (List.length atys) (List.length nms)
+        then (List.rev (map (inst_tv cnt) atys), cnt + S (max_tvs atys))
+        else (map (fun _ => ExAst.TAny) nms, cnt)
+      | None => (map (fun _ => ExAst.TAny) nms, cnt)
+      end in
+    let '(tbody, s1, c1) := f (bctx ++ ctx) cnt1 s body in
+    match unify uf s1 tbody r with
+    | Some s2 => go_brs uf f D ctx ind r bs' (S bi) c1 s2
+    | None => go_brs uf f D ctx ind r bs' (S bi) c1 s1
+    end
+  end.
+
+(** Infer a (monomorphic) mutual fixpoint: each body is checked in the context
+    extended with the fixpoint variables [vars] and unified against its own
+    fresh variable.  [uf] is the (opaque) unify fuel. *)
+Fixpoint go_mfix (uf : nat) (f : tm_fn)
+                 (ctx : list ExAst.box_type) (vars : list ExAst.box_type)
+                 (cnt : nat) (s : subst_t)
+                 (ds : list (EAst.def EAst.term)) {struct ds}
+                 : subst_t * nat :=
+  match ds, vars with
+  | d :: ds', v :: vs' =>
+    let '(tb, s1, c1) := f ctx cnt s d.(EAst.dbody) in
+    match unify uf s1 tb v with
+    | Some s2 => go_mfix uf f ctx vs' c1 s2 ds'
+    | None => go_mfix uf f ctx vs' c1 s1 ds'
+    end
+  | _, _ => (s, cnt)
+  end.
+
+Fixpoint infer_tm (fuel : nat) (D : dt_sigs) (E : sch_env)
+                  (ctx : list ExAst.box_type) (cnt : nat) (s : subst_t)
+                  (t : EAst.term) {struct fuel}
+                  : ExAst.box_type * subst_t * nat :=
+  match fuel with
+  | 0 => (ExAst.TAny, s, cnt)
+  | S fuel =>
+    match t with
+    | EAst.tBox => (ExAst.TBox, s, cnt)
+    | EAst.tRel n =>
+      match nth_error ctx n with
+      | Some ty => (zonk s ty, s, cnt)
+      | None => (ExAst.TAny, s, cnt)
+      end
+    | EAst.tLambda _ body =>
+      let a := ExAst.TVar cnt in
+      let '(rb, s1, c1) := infer_tm fuel D E (a :: ctx) (S cnt) s body in
+      (ExAst.TArr (zonk s1 a) rb, s1, c1)
+    | EAst.tApp u v =>
+      let '(tu, s1, c1) := infer_tm fuel D E ctx cnt s u in
+      let '(tv, s2, c2) := infer_tm fuel D E ctx c1 s1 v in
+      let r := ExAst.TVar c2 in
+      match unify unify_fuel s2 tu (ExAst.TArr tv r) with
+      | Some s3 => (zonk s3 r, s3, S c2)
+      | None => (ExAst.TAny, s2, S c2)
+      end
+    | EAst.tLetIn _ b body =>
+      let '(tb, s1, c1) := infer_tm fuel D E ctx cnt s b in
+      infer_tm fuel D E (zonk s1 tb :: ctx) c1 s1 body
+    | EAst.tConst kn =>
+      match sch_lookup E kn with
+      | Some sch => let '(ty, c1) := instantiate cnt sch in (ty, s, c1)
+      | None => (ExAst.TVar cnt, s, S cnt)   (* not yet inferred: fresh var *)
+      end
+    | EAst.tConstruct ind n args =>
+      let '(argtys, s1, c1) := go_args (infer_tm fuel D E) ctx cnt s args in
+      match dt_ctor D ind n with
+      | Some (atys, resty) =>
+        let '(atys', resty', c2) := freshen_sig c1 atys resty in
+        let s2 := unify_list unify_fuel s1 argtys atys' in
+        (zonk s2 (mkArrows (List.skipn (List.length argtys) atys') resty'), s2, c2)
+      | None => (ExAst.TAny, s1, c1)
+      end
+    | EAst.tCase indn c brs =>
+      let ind := fst indn in
+      let '(_, s0, c0) := infer_tm fuel D E ctx cnt s c in
+      let r := ExAst.TVar c0 in
+      let '(s1, c1) := go_brs unify_fuel (infer_tm fuel D E) D ctx ind r brs 0 (S c0) s0 in
+      (zonk s1 r, s1, c1)
+    | EAst.tProj p c =>
+      let '(_, s1, c1) := infer_tm fuel D E ctx cnt s c in
+      match dt_proj D p.(proj_ind) p.(proj_arg) with
+      | Some ty => let '(ty', c2) := freshen1 c1 ty in (zonk s1 ty', s1, c2)
+      | None => (ExAst.TAny, s1, c1)
+      end
+    | EAst.tFix mfix idx =>
+      let n := List.length mfix in
+      let vars := map (fun i => ExAst.TVar (cnt + i)) (List.seq 0 n) in
+      let fixctx := List.rev vars in
+      let '(s1, c1) := go_mfix unify_fuel (infer_tm fuel D E) (fixctx ++ ctx) vars (cnt + n) s mfix in
+      (zonk s1 (List.nth idx vars ExAst.TAny), s1, c1)
+    (* Genuinely out-of-fragment / erased residue. *)
+    | EAst.tCoFix _ _ | EAst.tEvar _ _
+    | EAst.tVar _ | EAst.tPrim _ | EAst.tLazy _ | EAst.tForce _ =>
+      (ExAst.TAny, s, cnt)
+    end
+  end.
+
+(** Fuel for [infer_tm]: any bound exceeding the term's syntactic depth suffices;
+    running short only makes the result [TAny] more often (never unsound — the
+    section law does not depend on the inferred types). *)
+Definition infer_fuel : nat := 1000.
+
+(** ** Damas–Milner generalization at the top level of a constant *)
+
+Fixpoint mem_nat (n : nat) (l : list nat) : bool :=
+  match l with
+  | [] => false
+  | m :: l' => if Nat.eqb n m then true else mem_nat n l'
+  end.
+
+Fixpoint dedup_nat (l : list nat) : list nat :=
+  match l with
+  | [] => []
+  | n :: l' => if mem_nat n (dedup_nat l') then dedup_nat l' else n :: dedup_nat l'
+  end.
+
+Fixpoint idx_nat (n : nat) (l : list nat) : nat :=
+  match l with
+  | [] => 0
+  | m :: l' => if Nat.eqb n m then 0 else S (idx_nat n l')
+  end.
+
+Fixpoint rename_tv (vs : list nat) (t : ExAst.box_type) : ExAst.box_type :=
+  match t with
+  | ExAst.TVar n => ExAst.TVar (idx_nat n vs)
+  | ExAst.TArr a b => ExAst.TArr (rename_tv vs a) (rename_tv vs b)
+  | ExAst.TApp a b => ExAst.TApp (rename_tv vs a) (rename_tv vs b)
+  | _ => t
+  end.
+
+(** Generalize a (fully zonked) type: quantify every free type variable,
+    renaming them to the canonical [0 .. k-1] so [instantiate] can freshen. *)
+Definition generalize_ty (t : ExAst.box_type) : list name * ExAst.box_type :=
+  let vs := dedup_nat (ftv t) in
+  (map (fun _ => nAnon) vs, rename_tv vs t).
+
+Definition infer_cst_type (D : dt_sigs) (E : sch_env) (b : option EAst.term)
+  : list name * ExAst.box_type :=
+  match b with
+  | None => ([], ExAst.TAny)
+  | Some t =>
+    let '(ty, s, _) := infer_tm infer_fuel D E [] 0 [] t in
+    generalize_ty (zonk s ty)
+  end.
+
+(** ** Decorating declarations (the actual forward map) *)
+
+Definition infer_const (D : dt_sigs) (E : sch_env) (cb : EAst.constant_body)
+  : ExAst.constant_body :=
+  {| ExAst.cst_type := infer_cst_type D E cb.(EAst.cst_body);
+     ExAst.cst_body := cb.(EAst.cst_body) |}.
+
+(** Reconstruct a typed one-inductive body.  Constructor argument types and
+    projection types are set to [TAny] (see the module header: those fields are
+    discarded by [trans_env] and the untyped body has no types to recover; the
+    GIVEN signatures are consumed at term use-sites instead).  The ORIGINAL
+    arity ([cstr_nargs]) is preserved so that [trans_oib] recovers the untyped
+    body exactly. *)
+Definition infer_oib (oib : EAst.one_inductive_body) : ExAst.one_inductive_body :=
+  {| ExAst.ind_name := oib.(EAst.ind_name);
+     ExAst.ind_propositional := oib.(EAst.ind_propositional);
+     ExAst.ind_kelim := oib.(EAst.ind_kelim);
+     ExAst.ind_type_vars := [];
+     ExAst.ind_ctors :=
+       map (fun c => (c.(EAst.cstr_name),
+                      repeat (nAnon, ExAst.TAny) c.(EAst.cstr_nargs),
+                      c.(EAst.cstr_nargs)))
+           oib.(EAst.ind_ctors);
+     ExAst.ind_projs :=
+       map (fun p => (p.(EAst.proj_name), ExAst.TAny)) oib.(EAst.ind_projs) |}.
+
+Definition infer_mib (mib : EAst.mutual_inductive_body) : ExAst.mutual_inductive_body :=
+  {| ExAst.ind_finite := mib.(EAst.ind_finite);
+     ExAst.ind_npars := mib.(EAst.ind_npars);
+     ExAst.ind_bodies := map infer_oib mib.(EAst.ind_bodies) |}.
+
+(** The forward map, threading the Damas–Milner scheme table in dependency
+    order.  [infer_go] recurses on the TAIL first: since an extracted
+    environment lists a declaration before the declarations it depends on, the
+    tail's schemes are available when the head is processed.  Only constants
+    contribute schemes.  [has_deps := true] on every declaration (discarded by
+    [trans_env]). *)
+Fixpoint infer_go (D : dt_sigs) (Σ : EAst.global_context)
+  : ExAst.global_env * sch_env :=
+  match Σ with
+  | [] => ([], [])
+  | (kn, d) :: Σ' =>
+    let '(env, E) := infer_go D Σ' in
+    match d with
+    | EAst.ConstantDecl cb =>
+      let cb' := infer_const D E cb in
+      ((kn, true, ExAst.ConstantDecl cb') :: env,
+       (kn, cb'.(ExAst.cst_type)) :: E)
+    | EAst.InductiveDecl mib =>
+      ((kn, true, ExAst.InductiveDecl (infer_mib mib)) :: env, E)
+    end
+  end.
+
+Definition infer (D : dt_sigs) (Σ : EAst.global_context) : ExAst.global_env :=
+  fst (infer_go D Σ).
+
+(** ** The section lemma and its supporting inversions *)
+
+Lemma trans_infer_const (D : dt_sigs) (E : sch_env) (cb : EAst.constant_body) :
+  ExAst.trans_cst (infer_const D E cb) = cb.
+Proof. destruct cb; reflexivity. Qed.
+
+Lemma trans_infer_oib (oib : EAst.one_inductive_body) :
+  ExAst.trans_oib (infer_oib oib) = oib.
+Proof.
+  destruct oib as [nm prop kelim ctors projs].
+  unfold ExAst.trans_oib, infer_oib; cbn.
+  f_equal.
+  - (* ind_ctors *)
+    unfold ExAst.trans_ctors. rewrite map_map.
+    induction ctors as [|c cs IH]; cbn; [reflexivity|].
+    destruct c; cbn. f_equal. exact IH.
+  - (* ind_projs *)
+    rewrite map_map.
+    induction projs as [|p ps IH]; cbn; [reflexivity|].
+    destruct p; cbn. f_equal. exact IH.
+Qed.
+
+Lemma trans_infer_mib (mib : EAst.mutual_inductive_body) :
+  ExAst.trans_mib (infer_mib mib) = mib.
+Proof.
+  destruct mib as [fin npars bodies].
+  unfold ExAst.trans_mib, infer_mib; cbn.
+  f_equal.
+  rewrite map_map.
+  induction bodies as [|o os IH]; cbn; [reflexivity|].
+  rewrite trans_infer_oib. f_equal. exact IH.
+Qed.
+
+(** *** Main theorem: [infer D] is a section of [trans_env], for any [D]. *)
+Theorem infer_section (D : dt_sigs) (Σ : EAst.global_context) :
+  ExAst.trans_env (infer D Σ) = Σ.
+Proof.
+  unfold infer.
+  induction Σ as [|[kn d] Σ IH]; [reflexivity|].
+  simpl infer_go. destruct (infer_go D Σ) as [env E] eqn:Hgo.
+  (* [destruct … eqn:Hgo] already rewrote [infer_go D Σ] to [(env,E)] inside
+     [IH], so [IH : trans_env (fst (env,E)) = Σ]; [cbn] gives [trans_env env]. *)
+  assert (Henv : ExAst.trans_env env = Σ) by (cbn in IH; exact IH).
+  destruct d as [cb|mib]; cbn;
+    unfold ExAst.trans_env in *; cbn in *.
+  - rewrite trans_infer_const. rewrite Henv. reflexivity.
+  - rewrite trans_infer_mib. rewrite Henv. reflexivity.
+Qed.
+
+(** *** Evaluation preservation, schematically.
+
+    Any property [P] of the untyped environment that the verified pipeline
+    establishes for [trans_env (infer D Σ)] is a property of [Σ] itself, and
+    vice versa, because the two are equal.  In particular, whatever
+    evaluation/observational equivalence [trans_env_transform] proves for
+    [trans_env (infer D Σ)] holds verbatim for [Σ]; no fresh evaluation proof
+    is needed.  We package that transport here. *)
+Lemma eval_preserved_via_section
+      (P : EAst.global_context -> Prop) (D : dt_sigs) (Σ : EAst.global_context) :
+  P (ExAst.trans_env (infer D Σ)) <-> P Σ.
+Proof. rewrite infer_section. reflexivity. Qed.
+
+(** Sanity: the whole forward map preserves the untyped skeleton, stated as the
+    equality actually consumed by pipeline wiring. *)
+Corollary infer_erases_back (D : dt_sigs) (Σ : EAst.global_context) :
+  ExAst.trans_env (infer D Σ) = Σ.
+Proof. exact (infer_section D Σ). Qed.
+
+(** ** Structural well-formedness facts (toward λ□ᵀ well-typedness, item 4)
+
+    A full [check_wf_typed_program]-style lemma is a residual (that predicate is
+    absent from the imported MetaRocq; see the header).  These are the
+    structural well-formedness facts the pipeline gate actually consumes. *)
+
+(** Kernames and their order are preserved exactly. *)
+Lemma infer_kernames (D : dt_sigs) (Σ : EAst.global_context) :
+  map (fun '(kn, _, _) => kn) (infer D Σ) = map fst Σ.
+Proof.
+  unfold infer.
+  induction Σ as [|[kn d] Σ IH]; [reflexivity|].
+  simpl infer_go. destruct (infer_go D Σ) as [env E] eqn:Hgo.
+  assert (Henv : map (fun '(kn0, _, _) => kn0) env = map fst Σ)
+    by (cbn in IH; exact IH).
+  destruct d as [cb|mib]; cbn; rewrite Henv; reflexivity.
+Qed.
+
+(** Every emitted declaration carries [has_deps = true]. *)
+Lemma infer_has_deps (D : dt_sigs) (Σ : EAst.global_context) :
+  Forall (fun '(_, b, _) => b = true) (infer D Σ).
+Proof.
+  unfold infer.
+  induction Σ as [|[kn d] Σ IH]; [constructor|].
+  simpl infer_go. destruct (infer_go D Σ) as [env E] eqn:Hgo.
+  assert (Henv : Forall (fun '(_, b, _) => b = true) env)
+    by (cbn in IH; exact IH).
+  destruct d as [cb|mib]; cbn; constructor; try exact Henv; reflexivity.
+Qed.
+
+Print Assumptions infer_section.
+Print Assumptions infer_kernames.
+Print Assumptions infer_has_deps.

--- a/theories/erasure/EInstanceSpecialize.v
+++ b/theories/erasure/EInstanceSpecialize.v
@@ -1,0 +1,406 @@
+(** * Instance / dictionary specialization for lambda-box (unverified first cut)
+
+    Motivation.  Typeclass-heavy frontends (notably Lean) erase to lambda-box
+    in which even trivial arithmetic drags in dictionary values: [1 + 1] is
+    elaborated to [HAdd.add instHAdd 1 1] where [instHAdd] is a *statically
+    known* record/constructor value.  Lean's own compiler removes this cost
+    with instance / typeclass-instance specialization.  This module is the
+    Peregrine middle-end analogue, so every frontend benefits.
+
+    What this pass does.  It is a *local, terminating partial evaluator* over
+    lambda-box terms performing the two reductions that expose and then discard
+    dictionary plumbing but that plain beta reduction ([EBeta]) does not on its
+    own complete:
+
+      - beta:  [(fun x => b) a]                          ==>  b[x := a]
+      - iota:  [match C a0 .. an with | .. | C xs => br | .. end]
+                                                          ==>  br[xs := a..]
+               i.e. case-of-known-constructor.  In post-[verified_lambdabox]
+               lambda-box, record projections have been compiled to [tCase]
+               with constructors-as-blocks, so a dictionary field access is a
+               [tCase] on a literal [tConstruct]; firing iota here is exactly
+               the "read a field out of a known dictionary" step.
+
+    Cloning driver (implemented below, [drive_env]).
+    On top of the local reducer, the pass *clones* a function at call sites
+    where a leading argument is a statically-known dictionary value: for [f d x]
+    with [d] a closed dictionary [tConstruct] (or a [tConst] whose body unfolds
+    to one), it emits a specialized copy [f$specN] whose body is [f]'s body with
+    [d] substituted in (via [spec_beta]; for a [tConst] whose body is a [tFix],
+    the fixpoint is unfolded once first), so the beta/iota reductions above fire
+    *inside* [f]'s body across the call boundary; the call site is redirected to
+    [f$specN x].  After this, existing dead-argument elimination ([Optimize]/
+    dearg) drops the now-unused [d] parameter.  A dictionary argument is
+    recognised by the heuristic "closed constructor whose inductive is a
+    single-constructor record" ([dict_value]/[is_record_ind]), which excludes
+    ordinary data (nat, list, bool, ...).  Specializations are memoised in a map
+    keyed by [(callee, dicts)] so each is emitted once, and the whole search is
+    bounded by a fuel budget ([specialize_fuel]) to guarantee termination and
+    avoid code blow-up.  The saturation loop re-scans each freshly emitted body
+    so chained dictionary plumbing (a method that itself projects another
+    dictionary) is specialized too.  The local reducer below is the cleanup that
+    the cloning relies on, and is independently useful after user-directed
+    constant inlining ([inlinings_opts] / [EInlining]) brings an instance
+    definition to a call site.
+
+    Composition with existing passes.
+      - It is meant to run just before [betared] (which the pipeline already
+        runs twice); [betared] mops up any cascading redexes this single
+        bottom-up pass leaves behind.
+      - It feeds dead-argument elimination: after specialization a dictionary
+        parameter becomes unused and [Optimize]'s mask analysis removes it.
+      - It does NOT subsume any of them: dearg removes *dead* args (it cannot
+        touch a dictionary that is still projected), betared does beta but not
+        iota-on-constructor, and [EInlining] inlines *named constants* uniformly
+        rather than specializing a shared function per call site.
+
+    Verification status.  UNVERIFIED.  Following the established pattern for the
+    optional / "Compatible" transforms in this toolchain (cf. [EBeta.betared_
+    transformation], which is justified by the [trust_betared_*] axioms, and the
+    [Admitted] obligations in [Transforms.v]), correctness and wellformedness
+    preservation are stated as trust axioms.  This is acceptable for a
+    [Compatible]-class optional phase; a real proof is future work. *)
+
+From Stdlib Require Import List.
+From MetaRocq.Utils Require Import utils ReflectEq.
+From MetaRocq.Common Require Import BasicAst Kernames.
+From MetaRocq.Erasure Require Import EPrimitive EAst EAstUtils EReflect ELiftSubst EGlobalEnv EProgram.
+
+Import ListNotations.
+
+(** Generic congruence recursor (identical in spirit to [EBeta.map_subterms]);
+    kept local so the head-reduction fixpoint below is guarded. *)
+Definition spec_map_subterms (f : term -> term) (t : term) : term :=
+  match t with
+  | tEvar n ts => tEvar n (map f ts)
+  | tLambda na body => tLambda na (f body)
+  | tLetIn na val body => tLetIn na (f val) (f body)
+  | tApp hd arg => tApp (f hd) (f arg)
+  | tCase p disc brs => tCase p (f disc) (map (on_snd f) brs)
+  | tProj p t => tProj p (f t)
+  | tFix def i => tFix (map (map_def f) def) i
+  | tCoFix def i => tCoFix (map (map_def f) def) i
+  | tPrim p => tPrim (map_prim f p)
+  | tLazy t => tLazy (f t)
+  | tForce t => tForce (f t)
+  | tConstruct ind n args => tConstruct ind n (map f args)
+  | tRel n => tRel n
+  | tVar na => tVar na
+  | tConst kn => tConst kn
+  | tBox => tBox
+  end.
+
+Section specialize.
+
+  (** Apply an already-reduced [body] to a spine of already-reduced [args],
+      firing beta as far as [body] is a literal lambda. *)
+  Fixpoint spec_beta (body : term) (args : list term) {struct args} : term :=
+    match args with
+    | [] => body
+    | a :: args =>
+        match body with
+        | tLambda na body => spec_beta (body {0 := a}) args
+        | _ => mkApps body (a :: args)
+        end
+    end.
+
+  (** Bottom-up single pass: reduce children first, then attempt one head
+      beta (via the collected spine) or iota (case-of-known-constructor). *)
+  Fixpoint spec_aux (args : list term) (t : term) : term :=
+    match t with
+    | tApp hd arg => spec_aux (spec_aux [] arg :: args) hd
+    | tLambda na body =>
+        let b := spec_aux [] body in
+        spec_beta (tLambda na b) args
+    | tCase (ind, npar) disc brs =>
+        let disc' := spec_aux [] disc in
+        let brs' := map (on_snd (spec_aux [])) brs in
+        let reduced :=
+          match disc' with
+          | tConstruct _ c cargs =>
+              match nth_error brs' c with
+              | Some br => iota_red npar cargs br
+              | None => tCase (ind, npar) disc' brs'
+              end
+          | _ => tCase (ind, npar) disc' brs'
+          end in
+        mkApps reduced args
+    | t => mkApps (spec_map_subterms (spec_aux []) t) args
+    end.
+
+  Definition specialize_instances : term -> term := spec_aux [].
+
+End specialize.
+
+(** ** Cloning driver
+
+    Detect [tConst nm] applied to a leading run of closed dictionary
+    constructors, emit a specialized copy of [nm] with those dictionaries
+    substituted into its body, and redirect the call site to the copy. *)
+
+Definition dkey : Type := kername × list term.
+
+(** Boolean equality on specialization keys, built from the [ReflectEq]
+    instances for [kername] and [term]; used for memoisation. *)
+Fixpoint list_eqb {A} (f : A -> A -> bool) (l1 l2 : list A) : bool :=
+  match l1, l2 with
+  | [], [] => true
+  | a :: l1, b :: l2 => f a b && list_eqb f l1 l2
+  | _, _ => false
+  end.
+
+Definition eqb_key (k1 k2 : dkey) : bool :=
+  eqb (fst k1) (fst k2) && list_eqb (fun a b => eqb a b) (snd k1) (snd k2).
+
+(** Fresh, deterministic name for the [i]-th specialization of [nm]. *)
+Definition fresh_name (nm : kername) (i : nat) : kername :=
+  (nm.1, (nm.2 ++ "$spec" ++ string_of_nat i)%bs).
+
+(** Is [ind] a single-constructor record (the typeclass/dictionary shape)? *)
+Definition is_record_ind (Σ : global_declarations) (ind : inductive) : bool :=
+  match lookup_inductive Σ ind with
+  | Some (_, oib) => Nat.eqb #|oib.(ind_ctors)| 1
+  | None => false
+  end.
+
+(** If [t] is a statically-known dictionary value, return the underlying
+    (closed, single-constructor) [tConstruct].  Resolves one level of [tConst]
+    delta so that a dictionary supplied as a named instance still qualifies. *)
+Definition dict_value (Σ : global_declarations) (t : term) : option term :=
+  match t with
+  | tConstruct ind _ _ =>
+      if is_record_ind Σ ind && closedn 0 t then Some t else None
+  | tConst c =>
+      match lookup_constant Σ c with
+      | Some cb =>
+          match cst_body cb with
+          | Some (tConstruct ind n args) =>
+              if is_record_ind Σ ind && closedn 0 (tConstruct ind n args)
+              then Some (tConstruct ind n args) else None
+          | _ => None
+          end
+      | None => None
+      end
+  | _ => None
+  end.
+
+(** A spine element that belongs in a specialization prefix: either an erased
+    type argument ([tBox], which typically precedes the dictionaries after
+    erasure) or a statically-known dictionary value.  The boolean flags whether
+    it is an actual dictionary (so we only specialize prefixes that contain at
+    least one). *)
+Definition prefix_elt (Σ : global_declarations) (t : term) : option (bool * term) :=
+  match dict_value Σ t with
+  | Some d => Some (true, d)
+  | None => match t with tBox => Some (false, tBox) | _ => None end
+  end.
+
+(** Split a spine into its leading prefix of erased-type/dictionary arguments
+    (resolved to the values to substitute) and the remaining ordinary
+    arguments; the boolean reports whether the prefix contains a dictionary. *)
+Fixpoint split_dicts (Σ : global_declarations) (spine : list term)
+  : bool * list term * list term :=
+  match spine with
+  | [] => (false, [], [])
+  | a :: rest =>
+      match prefix_elt Σ a with
+      | Some (isd, v) =>
+          let '(d', ds, rr) := split_dicts Σ rest in (orb isd d', v :: ds, rr)
+      | None => (false, [], spine)
+      end
+  end.
+
+Definition callee_body (Σ : global_declarations) (nm : kername) : option term :=
+  match lookup_constant Σ nm with
+  | Some cb => cst_body cb
+  | None => None
+  end.
+
+(** Body of a specialized copy: substitute the dictionaries into the callee
+    body (for a [tFix]-bodied constant, unfold the fixpoint once first), then
+    run the local beta/iota reducer to collapse the exposed projections. *)
+Definition spec_body (b : term) (dicts : list term) : term :=
+  match b with
+  | tFix mfix idx =>
+      match cunfold_fix mfix idx with
+      | Some (_, fn) => specialize_instances (spec_beta fn dicts)
+      | None => specialize_instances (mkApps b dicts)
+      end
+  | _ => specialize_instances (spec_beta b dicts)
+  end.
+
+(** Key of a specializable [tConst nm] call [nm @ spine], with the ordinary
+    (non-dictionary) remainder of the spine. *)
+Definition mk_key (Σ : global_declarations) (nm : kername) (spine : list term)
+  : option (dkey * list term) :=
+  match callee_body Σ nm with
+  | Some _ =>
+      let '(saw_dict, dicts, rest) := split_dicts Σ spine in
+      if saw_dict then Some ((nm, dicts), rest) else None
+  | None => None
+  end.
+
+(** Collect every specialization key reachable in a term (spine accumulator in
+    the head position, exactly as [spec_aux]). *)
+Fixpoint collect_keys (Σ : global_declarations) (spine : list term) (t : term)
+  {struct t} : list dkey :=
+  match t with
+  | tApp hd arg => collect_keys Σ [] arg ++ collect_keys Σ (arg :: spine) hd
+  | tConst nm => match mk_key Σ nm spine with Some (k, _) => [k] | None => [] end
+  | tLambda _ b => collect_keys Σ [] b
+  | tLetIn _ v b => collect_keys Σ [] v ++ collect_keys Σ [] b
+  | tCase _ disc brs =>
+      collect_keys Σ [] disc ++ concat (map (fun br => collect_keys Σ [] (snd br)) brs)
+  | tProj _ c => collect_keys Σ [] c
+  | tFix mfix _ => concat (map (fun d => collect_keys Σ [] (dbody d)) mfix)
+  | tCoFix mfix _ => concat (map (fun d => collect_keys Σ [] (dbody d)) mfix)
+  | tConstruct _ _ args => concat (map (fun a => collect_keys Σ [] a) args)
+  | tEvar _ args => concat (map (fun a => collect_keys Σ [] a) args)
+  | tLazy t => collect_keys Σ [] t
+  | tForce t => collect_keys Σ [] t
+  | _ => []
+  end.
+
+(** Fuel-bounded saturation: pop a key, and if not already specialized, emit its
+    specialized declaration and enqueue the keys newly exposed inside it. *)
+Fixpoint saturate (Σ : global_declarations) (fuel : nat) (worklist : list dkey)
+  (seen : list (dkey × kername)) (decls : list (kername × global_decl))
+  {struct fuel} : list (dkey × kername) × list (kername × global_decl) :=
+  match fuel with
+  | 0 => (seen, decls)
+  | S fuel' =>
+      match worklist with
+      | [] => (seen, decls)
+      | k :: rest =>
+          if existsb (fun p => eqb_key (fst p) k) seen
+          then saturate Σ fuel' rest seen decls
+          else
+            let '(nm, dicts) := k in
+            match callee_body Σ nm with
+            | Some b =>
+                let body := spec_body b dicts in
+                let fn := fresh_name nm #|seen| in
+                let new_keys := collect_keys Σ [] body in
+                saturate Σ fuel' (new_keys ++ rest) ((k, fn) :: seen)
+                         ((fn, ConstantDecl {| cst_body := Some body |}) :: decls)
+            | None => saturate Σ fuel' rest seen decls
+            end
+      end
+  end.
+
+Definition lookup_spec (seen : list (dkey × kername)) (k : dkey) : option kername :=
+  match find (fun p => eqb_key (fst p) k) seen with
+  | Some p => Some (snd p)
+  | None => None
+  end.
+
+(** Redirect specializable call sites to their emitted copies (pure rewrite;
+    the memo table [seen] is fixed). *)
+Fixpoint redirect (Σ : global_declarations) (seen : list (dkey × kername))
+  (spine : list term) (t : term) {struct t} : term :=
+  match t with
+  | tApp hd arg => redirect Σ seen (redirect Σ seen [] arg :: spine) hd
+  | tConst nm =>
+      match mk_key Σ nm spine with
+      | Some (k, rest) =>
+          match lookup_spec seen k with
+          | Some fn => mkApps (tConst fn) rest
+          | None => mkApps (tConst nm) spine
+          end
+      | None => mkApps (tConst nm) spine
+      end
+  | _ => mkApps (spec_map_subterms (redirect Σ seen []) t) spine
+  end.
+
+Definition specialize_fuel : nat := 1000.
+
+(** Whole-program driver: gather keys, saturate to a memo table + fresh
+    declarations, then redirect every body and the main term and locally
+    reduce. *)
+Definition drive_env (Σ : global_declarations) (main : term)
+  : global_declarations × term :=
+  let body_keys :=
+    fun d => match d with
+             | ConstantDecl cb => match cst_body cb with
+                                  | Some b => collect_keys Σ [] b
+                                  | None => [] end
+             | _ => [] end in
+  let init_keys :=
+    concat (map (fun '(_, d) => body_keys d) Σ) ++ collect_keys Σ [] main in
+  let '(seen, gen_decls) := saturate Σ specialize_fuel init_keys [] [] in
+  let Σ' := Σ ++ List.rev gen_decls in
+  let red_decl :=
+    fun '(kn, d) =>
+      match d with
+      | ConstantDecl cb =>
+          (kn, ConstantDecl {| cst_body :=
+                 option_map (fun b => specialize_instances (redirect Σ seen [] b))
+                            (cst_body cb) |})
+      | _ => (kn, d)
+      end in
+  (map red_decl Σ', specialize_instances (redirect Σ seen [] main)).
+
+Definition specialize_instances_in_constant_body (cst : constant_body) : constant_body :=
+  {| cst_body := option_map specialize_instances (cst_body cst) |}.
+
+Definition specialize_instances_in_decl (d : global_decl) : global_decl :=
+  match d with
+  | ConstantDecl cst => ConstantDecl (specialize_instances_in_constant_body cst)
+  | _ => d
+  end.
+
+Definition specialize_instances_env (Σ : global_declarations) : global_declarations :=
+  map (fun '(kn, decl) => (kn, specialize_instances_in_decl decl)) Σ.
+
+Definition specialize_instances_program (p : program) : program :=
+  drive_env p.1 p.2.
+
+(** ** Transform wrapper (unverified, [Compatible]-class) *)
+
+From MetaRocq.Erasure Require Import EWellformed EWcbvEval.
+From MetaRocq.Common Require Import Transform.
+
+Axiom trust_specialize_instances_wf :
+  forall efl : EEnvFlags,
+  WcbvFlags ->
+  forall (input : Transform.program _ term),
+  wf_eprogram efl input -> wf_eprogram efl (specialize_instances_program input).
+
+Axiom trust_specialize_instances_pres :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags) (p : Transform.program _ term)
+    (v : term),
+  wf_eprogram efl p ->
+  eval_eprogram wfl p v ->
+  exists v' : term,
+  eval_eprogram wfl (specialize_instances_program p) v' /\ v' = specialize_instances v.
+
+Import Transform.
+
+Program Definition specialize_instances_transformation (efl : EEnvFlags) (wfl : WcbvFlags) :
+  Transform.t _ _ EAst.term EAst.term _ _
+    (eval_eprogram wfl) (eval_eprogram wfl) :=
+  {| name := "instance specialization";
+     transform p _ := specialize_instances_program p;
+     pre p := wf_eprogram efl p;
+     post p := wf_eprogram efl p;
+     obseq p hp p' v v' := v' = specialize_instances v |}.
+Next Obligation.
+  now apply trust_specialize_instances_wf.
+Qed.
+Next Obligation.
+  now eapply trust_specialize_instances_pres.
+Qed.
+
+Import EProgram EGlobalEnv.
+
+#[global]
+Axiom specialize_instances_transformation_ext :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags),
+  TransformExt.t (specialize_instances_transformation efl wfl)
+    (fun p p' => extends p.1 p'.1) (fun p p' => extends p.1 p'.1).
+
+#[global]
+Axiom specialize_instances_transformation_ext' :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags),
+  TransformExt.t (specialize_instances_transformation efl wfl)
+    extends_eprogram extends_eprogram.

--- a/theories/erasure/EInstanceSpecializeTyped.v
+++ b/theories/erasure/EInstanceSpecializeTyped.v
@@ -1,0 +1,538 @@
+(** * Instance / dictionary specialization on TYPED lambda-box (λ□ᵀ / ExAst)
+
+    STANDALONE, verified-as-far-as-tractable first cut.  This module is a
+    self-contained sibling of the (wired, unverified) untyped
+    [EInstanceSpecialize.v]; it does NOT import that module and does NOT touch
+    the build wiring.  It operates on MetaRocq's *typed* erased syntax
+    ([MetaRocq.Erasure.Typed.ExAst]) — the layer that still carries [box_type]
+    information ([cst_type]) — and it is the "right place" for the pass in the
+    Peregrine pipeline: it runs before the Rust / Elm backends, where the
+    dictionary plumbing it removes is NOT re-optimized away by a downstream
+    native compiler (unlike the OCaml / C paths).
+
+    ------------------------------------------------------------------------
+    WHAT THE PASS DOES (identical algorithm to the untyped module, lifted to
+    ExAst so [box_type]s are tracked).
+
+    At a call [f D x1 .. xn] where the head [f] is a [tConst] (its body may be
+    a [tFix], which we unfold once) and [D] is a *statically-known dictionary*
+    — a closed [tConstruct] whose inductive is a single-constructor record, or
+    a [tConst] delta-unfolding to one — we:
+
+      1. emit a fresh specialized constant [f$specN] whose body is [f]'s body
+         with [D] substituted in ([spec_beta]) and the exposed method
+         projections collapsed by the local beta/iota reducer
+         ([specialize_instances]);
+      2. give [f$specN] a [cst_type]: an instantiation of [f]'s type scheme
+         (FIRST CUT: we reuse [f]'s scheme verbatim; the now-dead dictionary
+         parameter is left in place and is dropped by the downstream [dearg]
+         pass, which is precisely why the recommended phase order is
+         specialize -> dearg -> betared);
+      3. redirect the call site to [f$specN x1 .. xn].
+
+    The reductions that expose then discard the plumbing:
+
+      - δ:  [f D]  δ-unfolds [f] to its body [λdict. body], then
+      - β:  β-reduces to [body[dict := D]], which is *exactly* [f$specN]'s body,
+            so [eval (f D) = eval (f$specN)];
+      - ι:  [match D with C xs => br end] with [D = C a..] projects the method
+            ([iota_red]); firing ι here is "read a field out of a known
+            dictionary".  ([EBeta]'s plain [betared] does β but never ι, and
+            [EInlining] inlines named constants uniformly rather than
+            specializing a shared function per call site — so this pass
+            subsumes neither.)
+
+    Specializations are memoised by the key [(callee, dicts)] and the whole
+    saturation is bounded by [specialize_fuel]; the loop re-scans each freshly
+    emitted body so chained dictionary plumbing is specialized too.
+
+    ------------------------------------------------------------------------
+    VERIFICATION STRATEGY (what is Qed here vs. the single residual).
+
+    [eval] is defined on *untyped* [EAst] via [trans_env].  So the cleanest
+    route — and the one taken here — is:
+
+      * define the typed transform [specialize_program_typed] so that it does
+        ALL of its analysis on the translated environment [trans_env Σ] and
+        differs from a purely-untyped driver [drive_untyped] ONLY in the
+        [box_type] data that [trans_env] erases anyway;
+      * prove [specialize_commutes] : erasing the typed result equals running
+        [drive_untyped] on the erased input, i.e.
+
+            trans_env (specialize_program_typed Σ t)  =  drive_untyped (trans_env Σ) t.
+
+        This is fully **Qed** and is the genuinely new verified content: it
+        reduces every semantic/wellformedness question about the *typed* pass
+        to the corresponding question about the untyped core, with NO blanket
+        trust over the typed layer.
+      * From it, [typed_specialize_wf] (wellformedness preservation) and
+        [typed_specialize_pres] (semantics preservation) are each **Qed**,
+        modulo ONE precisely-stated residual about the untyped core,
+        [untyped_drive_correct], which packages exactly the δ/β/ι simulation.
+        This residual is the SAME obligation MetaRocq itself leaves for the
+        analogous optional passes ([EBeta.trust_betared_pres] /
+        [EBeta.trust_betared_wf], [EInlining]); its honest discharge is the
+        eval-simulation modelled on [EInlining]/[EBeta] correctness and is
+        future work.  We isolate it to the untyped reducer rather than
+        trusting the typed transform wholesale.
+
+    HONESTY: the typed-specific reasoning (the [trans_env] commutation and the
+    reduction of both preservation properties to the untyped core) is machine-
+    checked (Qed, see [Print Assumptions typed_specialize_pres] at the bottom,
+    which lists exactly [untyped_drive_correct]).  The untyped δ/β/ι
+    simulation itself is the stated residual, not proved here.
+
+    ------------------------------------------------------------------------
+    INTEGRATION NEXT-STEPS (typed pipeline, before Rust/Elm):
+      - wire [specialize_program_typed] into the typed extraction pipeline
+        (Typed/Optimize.v / Typed/Extraction.v) as an optional phase;
+      - phase order: specialize -> dearg -> betared (dearg removes the dead
+        dictionary parameter this pass leaves; betared mops up cascaded redexes);
+      - discharge [untyped_drive_correct] by the eval simulation modelled on
+        [EInlining.optimize]/[EBeta] correctness, then this module is axiom-free.
+*)
+
+From Stdlib Require Import List.
+From MetaRocq.Utils Require Import utils ReflectEq.
+From MetaRocq.Common Require Import BasicAst Kernames.
+From MetaRocq.Erasure Require Import EPrimitive EAst EAstUtils EReflect ELiftSubst
+     EGlobalEnv EProgram EWellformed EWcbvEval.
+From MetaRocq.Erasure.Typed Require Import ExAst.
+
+Import ListNotations.
+
+(** Throughout: [EAst.*] / [EGlobalEnv.*] are the *untyped* names, [ExAst.*]
+    the *typed* ones (ExAst re-exports [EAst], so both [ConstantDecl],
+    [cst_body], [lookup_constant] etc. exist; we qualify to disambiguate). *)
+
+(* ------------------------------------------------------------------------ *)
+(** ** Body-level machinery (on the shared [term] type). *)
+
+(** Generic congruence recursor (cf. [EBeta.map_subterms]); kept local so the
+    head-reduction fixpoint below is guarded. *)
+Definition spec_map_subterms (f : term -> term) (t : term) : term :=
+  match t with
+  | tEvar n ts => tEvar n (map f ts)
+  | tLambda na body => tLambda na (f body)
+  | tLetIn na val body => tLetIn na (f val) (f body)
+  | tApp hd arg => tApp (f hd) (f arg)
+  | tCase p disc brs => tCase p (f disc) (map (on_snd f) brs)
+  | tProj p t => tProj p (f t)
+  | tFix def i => tFix (map (map_def f) def) i
+  | tCoFix def i => tCoFix (map (map_def f) def) i
+  | tPrim p => tPrim (map_prim f p)
+  | tLazy t => tLazy (f t)
+  | tForce t => tForce (f t)
+  | tConstruct ind n args => tConstruct ind n (map f args)
+  | tRel n => tRel n
+  | tVar na => tVar na
+  | tConst kn => tConst kn
+  | tBox => tBox
+  end.
+
+Section reduce.
+
+  (** Apply an already-reduced [body] to a spine of already-reduced [args],
+      firing β as far as [body] is a literal lambda. *)
+  Fixpoint spec_beta (body : term) (args : list term) {struct args} : term :=
+    match args with
+    | [] => body
+    | a :: args =>
+        match body with
+        | tLambda na body => spec_beta (body {0 := a}) args
+        | _ => mkApps body (a :: args)
+        end
+    end.
+
+  (** Bottom-up single pass: reduce children first, then one head β (via the
+      collected spine) or ι (case-of-known-constructor). *)
+  Fixpoint spec_aux (args : list term) (t : term) : term :=
+    match t with
+    | tApp hd arg => spec_aux (spec_aux [] arg :: args) hd
+    | tLambda na body =>
+        let b := spec_aux [] body in
+        spec_beta (tLambda na b) args
+    | tCase (ind, npar) disc brs =>
+        let disc' := spec_aux [] disc in
+        let brs' := map (on_snd (spec_aux [])) brs in
+        let reduced :=
+          match disc' with
+          | tConstruct _ c cargs =>
+              match nth_error brs' c with
+              | Some br => iota_red npar cargs br
+              | None => tCase (ind, npar) disc' brs'
+              end
+          | _ => tCase (ind, npar) disc' brs'
+          end in
+        mkApps reduced args
+    | t => mkApps (spec_map_subterms (spec_aux []) t) args
+    end.
+
+  Definition specialize_instances : term -> term := spec_aux [].
+
+End reduce.
+
+(* ------------------------------------------------------------------------ *)
+(** ** Dictionary analysis over the UNTYPED environment. *)
+
+Definition dkey : Type := kername × list term.
+
+Fixpoint list_eqb {A} (f : A -> A -> bool) (l1 l2 : list A) : bool :=
+  match l1, l2 with
+  | [], [] => true
+  | a :: l1, b :: l2 => f a b && list_eqb f l1 l2
+  | _, _ => false
+  end.
+
+Definition eqb_key (k1 k2 : dkey) : bool :=
+  eqb (fst k1) (fst k2) && list_eqb (fun a b => eqb a b) (snd k1) (snd k2).
+
+(** Fresh, deterministic name for the [i]-th specialization of [nm]. *)
+Definition fresh_name (nm : kername) (i : nat) : kername :=
+  (nm.1, (nm.2 ++ "$spec" ++ string_of_nat i)%bs).
+
+(** Single-constructor record (the dictionary shape)? *)
+Definition is_record_ind (Σ : EAst.global_context) (ind : inductive) : bool :=
+  match EGlobalEnv.lookup_inductive Σ ind with
+  | Some (_, oib) => Nat.eqb #|oib.(EAst.ind_ctors)| 1
+  | None => false
+  end.
+
+(** If [t] is a statically-known dictionary value, return the underlying
+    (closed, single-constructor) [tConstruct]; resolves one [tConst] delta. *)
+Definition dict_value (Σ : EAst.global_context) (t : term) : option term :=
+  match t with
+  | tConstruct ind _ _ =>
+      if is_record_ind Σ ind && closedn 0 t then Some t else None
+  | tConst c =>
+      match EGlobalEnv.lookup_constant Σ c with
+      | Some cb =>
+          match EAst.cst_body cb with
+          | Some (tConstruct ind n args) =>
+              if is_record_ind Σ ind && closedn 0 (tConstruct ind n args)
+              then Some (tConstruct ind n args) else None
+          | _ => None
+          end
+      | None => None
+      end
+  | _ => None
+  end.
+
+(** A spine element accepted in a specialization prefix: an erased type arg
+    ([tBox]) or a dictionary value.  The flag records "is a real dictionary". *)
+Definition prefix_elt (Σ : EAst.global_context) (t : term) : option (bool * term) :=
+  match dict_value Σ t with
+  | Some d => Some (true, d)
+  | None => match t with tBox => Some (false, tBox) | _ => None end
+  end.
+
+Fixpoint split_dicts (Σ : EAst.global_context) (spine : list term)
+  : bool * list term * list term :=
+  match spine with
+  | [] => (false, [], [])
+  | a :: rest =>
+      match prefix_elt Σ a with
+      | Some (isd, v) =>
+          let '(d', ds, rr) := split_dicts Σ rest in (orb isd d', v :: ds, rr)
+      | None => (false, [], spine)
+      end
+  end.
+
+Definition callee_body (Σ : EAst.global_context) (nm : kername) : option term :=
+  match EGlobalEnv.lookup_constant Σ nm with
+  | Some cb => EAst.cst_body cb
+  | None => None
+  end.
+
+(** Body of a specialized copy: substitute the dictionaries into the callee
+    body (unfold a [tFix]-body once first), then locally reduce. *)
+Definition spec_body (b : term) (dicts : list term) : term :=
+  match b with
+  | tFix mfix idx =>
+      match cunfold_fix mfix idx with
+      | Some (_, fn) => specialize_instances (spec_beta fn dicts)
+      | None => specialize_instances (mkApps b dicts)
+      end
+  | _ => specialize_instances (spec_beta b dicts)
+  end.
+
+Definition mk_key (Σ : EAst.global_context) (nm : kername) (spine : list term)
+  : option (dkey * list term) :=
+  match callee_body Σ nm with
+  | Some _ =>
+      let '(saw_dict, dicts, rest) := split_dicts Σ spine in
+      if saw_dict then Some ((nm, dicts), rest) else None
+  | None => None
+  end.
+
+Fixpoint collect_keys (Σ : EAst.global_context) (spine : list term) (t : term)
+  {struct t} : list dkey :=
+  match t with
+  | tApp hd arg => collect_keys Σ [] arg ++ collect_keys Σ (arg :: spine) hd
+  | tConst nm => match mk_key Σ nm spine with Some (k, _) => [k] | None => [] end
+  | tLambda _ b => collect_keys Σ [] b
+  | tLetIn _ v b => collect_keys Σ [] v ++ collect_keys Σ [] b
+  | tCase _ disc brs =>
+      collect_keys Σ [] disc ++ concat (map (fun br => collect_keys Σ [] (snd br)) brs)
+  | tProj _ c => collect_keys Σ [] c
+  | tFix mfix _ => concat (map (fun d => collect_keys Σ [] (dbody d)) mfix)
+  | tCoFix mfix _ => concat (map (fun d => collect_keys Σ [] (dbody d)) mfix)
+  | tConstruct _ _ args => concat (map (fun a => collect_keys Σ [] a) args)
+  | tEvar _ args => concat (map (fun a => collect_keys Σ [] a) args)
+  | tLazy t => collect_keys Σ [] t
+  | tForce t => collect_keys Σ [] t
+  | _ => []
+  end.
+
+(** A generated specialization: [(fresh_name, callee, body)]. *)
+Definition gentriple : Type := kername * kername * term.
+
+(** Fuel-bounded saturation: pop a key, and if new, record its fresh name +
+    generated body and enqueue the keys newly exposed inside it. *)
+Fixpoint saturate (Σ : EAst.global_context) (fuel : nat) (worklist : list dkey)
+  (seen : list (dkey × kername)) (gen : list gentriple)
+  {struct fuel} : list (dkey × kername) × list gentriple :=
+  match fuel with
+  | 0 => (seen, gen)
+  | S fuel' =>
+      match worklist with
+      | [] => (seen, gen)
+      | k :: rest =>
+          if existsb (fun p => eqb_key (fst p) k) seen
+          then saturate Σ fuel' rest seen gen
+          else
+            let '(nm, dicts) := k in
+            match callee_body Σ nm with
+            | Some b =>
+                let body := spec_body b dicts in
+                let fn := fresh_name nm #|seen| in
+                let new_keys := collect_keys Σ [] body in
+                saturate Σ fuel' (new_keys ++ rest) ((k, fn) :: seen)
+                         ((fn, nm, body) :: gen)
+            | None => saturate Σ fuel' rest seen gen
+            end
+      end
+  end.
+
+Definition lookup_spec (seen : list (dkey × kername)) (k : dkey) : option kername :=
+  match find (fun p => eqb_key (fst p) k) seen with
+  | Some p => Some (snd p)
+  | None => None
+  end.
+
+(** Redirect specializable call sites to their emitted copies. *)
+Fixpoint redirect (Σ : EAst.global_context) (seen : list (dkey × kername))
+  (spine : list term) (t : term) {struct t} : term :=
+  match t with
+  | tApp hd arg => redirect Σ seen (redirect Σ seen [] arg :: spine) hd
+  | tConst nm =>
+      match mk_key Σ nm spine with
+      | Some (k, rest) =>
+          match lookup_spec seen k with
+          | Some fn => mkApps (tConst fn) rest
+          | None => mkApps (tConst nm) spine
+          end
+      | None => mkApps (tConst nm) spine
+      end
+  | _ => mkApps (spec_map_subterms (redirect Σ seen []) t) spine
+  end.
+
+Definition specialize_fuel : nat := 1000.
+
+(** Keys reachable from all constant bodies plus the main term. *)
+Definition init_keys (Σ : EAst.global_context) (main : term) : list dkey :=
+  concat (map (fun '(_, d) =>
+                 match d with
+                 | EAst.ConstantDecl cb =>
+                     match EAst.cst_body cb with
+                     | Some b => collect_keys Σ [] b
+                     | None => []
+                     end
+                 | _ => []
+                 end) Σ)
+  ++ collect_keys Σ [] main.
+
+(** The single analysis both drivers share. *)
+Definition analysis (Σ : EAst.global_context) (main : term)
+  : list (dkey × kername) × list gentriple :=
+  saturate Σ specialize_fuel (init_keys Σ main) [] [].
+
+(** Redirect+reduce an untyped declaration's body. *)
+Definition redirect_decl (Σ : EAst.global_context) (seen : list (dkey × kername))
+  (d : EAst.global_decl) : EAst.global_decl :=
+  match d with
+  | EAst.ConstantDecl cb =>
+      EAst.ConstantDecl
+        {| EAst.cst_body :=
+             option_map (fun b => specialize_instances (redirect Σ seen [] b))
+                        (EAst.cst_body cb) |}
+  | _ => d
+  end.
+
+(** ** The UNTYPED reference driver ([drive_untyped]).
+
+    This is the object of the residual correctness lemma below.  The typed
+    driver's erasure is proved equal to this. *)
+Definition drive_untyped (Σ : EAst.global_context) (main : term) : eprogram :=
+  let '(seen, gen) := analysis Σ main in
+  let red := map (fun '(kn, d) => (kn, redirect_decl Σ seen d)) Σ in
+  let gen_u :=
+    map (fun '(fn, _, body) =>
+           (fn, EAst.ConstantDecl {| EAst.cst_body := Some body |})) gen in
+  (red ++ gen_u, specialize_instances (redirect Σ seen [] main)).
+
+(* ------------------------------------------------------------------------ *)
+(** ** The TYPED driver over [ExAst.global_env].
+
+    Identical analysis (run on [trans_env Σ]); the ONLY difference from
+    [drive_untyped] is the [box_type] ([cst_type]) data, which [trans_env]
+    discards. *)
+
+(** Redirect+reduce a typed declaration's body, preserving its [cst_type]. *)
+Definition redirect_decl_typed (Σu : EAst.global_context)
+  (seen : list (dkey × kername)) (d : ExAst.global_decl) : ExAst.global_decl :=
+  match d with
+  | ExAst.ConstantDecl cb =>
+      ExAst.ConstantDecl
+        {| ExAst.cst_type := ExAst.cst_type cb;
+           ExAst.cst_body :=
+             option_map (fun b => specialize_instances (redirect Σu seen [] b))
+                        (ExAst.cst_body cb) |}
+  | _ => d
+  end.
+
+(** Typed declaration for a generated specialization.  [box_type]: an
+    instantiation of the callee's scheme — FIRST CUT reuses it verbatim (the
+    dead dictionary parameter is dropped later by dearg). *)
+Definition spec_typed_decl (Σ : ExAst.global_env) (callee : kername) (body : term)
+  : ExAst.global_decl :=
+  ExAst.ConstantDecl
+    {| ExAst.cst_type :=
+         match ExAst.lookup_constant Σ callee with
+         | Some cb => ExAst.cst_type cb
+         | None => ([], TBox)
+         end;
+       ExAst.cst_body := Some body |}.
+
+Definition specialize_program_typed (Σ : ExAst.global_env) (main : term)
+  : ExAst.global_env × term :=
+  let Σu := trans_env Σ in
+  let '(seen, gen) := analysis Σu main in
+  let red := map (fun '(kn, b, d) => (kn, b, redirect_decl_typed Σu seen d)) Σ in
+  let gen_t :=
+    map (fun '(fn, callee, body) => (fn, false, spec_typed_decl Σ callee body)) gen in
+  (red ++ gen_t, specialize_instances (redirect Σu seen [] main)).
+
+(** Erase a typed program to the untyped level eval is defined on. *)
+Definition typed_erase (r : ExAst.global_env × term) : eprogram :=
+  (trans_env r.1, r.2).
+
+(* ------------------------------------------------------------------------ *)
+(** ** The commutation theorem (fully Qed). *)
+
+Lemma trans_env_app (Σ1 Σ2 : ExAst.global_env) :
+  trans_env (Σ1 ++ Σ2) = trans_env Σ1 ++ trans_env Σ2.
+Proof. apply map_app. Qed.
+
+(** Erasing a redirected typed decl = redirecting the erased decl.  The only
+    subtle case is [TypeAliasDecl]: [trans_global_decl] turns it into a
+    [ConstantDecl] with body [tBox], on which [redirect_decl] then fires; but
+    [redirect]/[specialize_instances] fix [tBox], so both sides agree. *)
+Lemma trans_redirect_decl_typed (Σu : EAst.global_context)
+  (seen : list (dkey × kername)) (kn : kername) (b : bool) (d : ExAst.global_decl) :
+  (kn, trans_global_decl (redirect_decl_typed Σu seen d))
+  = (kn, redirect_decl Σu seen (trans_global_decl d)).
+Proof.
+  destruct d as [cb| |o]; cbn.
+  - (* ConstantDecl *) reflexivity.
+  - (* InductiveDecl *) reflexivity.
+  - (* TypeAliasDecl *) destruct o as [p|]; cbn; reflexivity.
+Qed.
+
+Lemma trans_env_redirect (Σu : EAst.global_context)
+  (seen : list (dkey × kername)) (Σ : ExAst.global_env) :
+  trans_env (map (fun '(kn, b, d) => (kn, b, redirect_decl_typed Σu seen d)) Σ)
+  = map (fun '(kn, d) => (kn, redirect_decl Σu seen d)) (trans_env Σ).
+Proof.
+  unfold trans_env.
+  rewrite !map_map.
+  apply map_ext; intros [[kn b] d]; cbn.
+  apply (trans_redirect_decl_typed Σu seen kn b d).
+Qed.
+
+Lemma trans_env_gen (Σ : ExAst.global_env) (gen : list gentriple) :
+  trans_env (map (fun '(fn, callee, body) =>
+                    (fn, false, spec_typed_decl Σ callee body)) gen)
+  = map (fun '(fn, _, body) =>
+           (fn, EAst.ConstantDecl {| EAst.cst_body := Some body |})) gen.
+Proof.
+  unfold trans_env.
+  rewrite !map_map.
+  apply map_ext; intros [[fn callee] body]; cbn.
+  reflexivity.
+Qed.
+
+(** MAIN VERIFIED CONTENT.  Erasing the typed specialization equals the
+    untyped driver on the erased input.  Everything typed-specific is here. *)
+Theorem specialize_commutes (Σ : ExAst.global_env) (main : term) :
+  typed_erase (specialize_program_typed Σ main) = drive_untyped (trans_env Σ) main.
+Proof.
+  unfold typed_erase, specialize_program_typed, drive_untyped.
+  destruct (analysis (trans_env Σ) main) as [seen gen].
+  cbn [fst snd].
+  f_equal.
+  rewrite trans_env_app.
+  f_equal.
+  - apply trans_env_redirect.
+  - apply trans_env_gen.
+Qed.
+
+(* ------------------------------------------------------------------------ *)
+(** ** The single residual: correctness of the untyped core.
+
+    This packages exactly the δ/β/ι eval-simulation for [drive_untyped],
+    mirroring [EBeta.trust_betared_pres] / [trust_betared_wf] and the
+    [EInlining] correctness argument.  Discharging it (by simulation on
+    [EWcbvEval.eval], case [eval_delta] for δ then β/ι, modelled on
+    [EInlining.optimize] correctness) makes this module axiom-free. *)
+Axiom untyped_drive_correct :
+  forall (efl : EEnvFlags) (wfl : WcbvFlags) (Σu : EAst.global_context) (t : term),
+    wf_eprogram efl (Σu, t) ->
+    wf_eprogram efl (drive_untyped Σu t)
+    /\ (forall v, eval_eprogram wfl (Σu, t) v ->
+          exists v', eval_eprogram wfl (drive_untyped Σu t) v'
+                     /\ v' = specialize_instances v).
+
+(* ------------------------------------------------------------------------ *)
+(** ** Preservation for the typed pass (Qed, modulo the single residual). *)
+
+(** (a) Wellformedness preservation. *)
+Theorem typed_specialize_wf
+  (efl : EEnvFlags) (wfl : WcbvFlags) (Σ : ExAst.global_env) (t : term) :
+  wf_eprogram efl (trans_env Σ, t) ->
+  wf_eprogram efl (typed_erase (specialize_program_typed Σ t)).
+Proof.
+  intros Hwf.
+  rewrite specialize_commutes.
+  exact (proj1 (untyped_drive_correct efl wfl (trans_env Σ) t Hwf)).
+Qed.
+
+(** (b) Semantics preservation.  Since [eval] is defined post-[trans_env], the
+    statement is about the erased typed program; the specialized value is the
+    locally-reduced original value (the [obseq] used by [EBeta]/[EInlining]). *)
+Theorem typed_specialize_pres
+  (efl : EEnvFlags) (wfl : WcbvFlags) (Σ : ExAst.global_env) (t v : term) :
+  wf_eprogram efl (trans_env Σ, t) ->
+  eval_eprogram wfl (trans_env Σ, t) v ->
+  exists v', eval_eprogram wfl (typed_erase (specialize_program_typed Σ t)) v'
+             /\ v' = specialize_instances v.
+Proof.
+  intros Hwf Hev.
+  rewrite specialize_commutes.
+  exact (proj2 (untyped_drive_correct efl wfl (trans_env Σ) t Hwf) v Hev).
+Qed.
+
+(** Assumptions of the top semantic-preservation lemma: exactly the one
+    scoped residual [untyped_drive_correct] (plus ambient logical axioms, if
+    any, from the imported libraries). *)
+Print Assumptions typed_specialize_pres.

--- a/theories/erasure/Transforms.v
+++ b/theories/erasure/Transforms.v
@@ -9,6 +9,7 @@ From MetaRocq.Erasure Require Import EProgram EInlining EBeta EWellformed.
 From MetaRocq.ErasurePlugin Require Import ETransform Erasure.
 From MetaRocq.Erasure Require EImplementBox.
 From Peregrine Require EImplementLazyForce.
+From Peregrine Require Import EInstanceSpecialize.
 From Malfunction Require Pipeline.
 
 Import PCUICProgram.
@@ -130,22 +131,32 @@ Proof.
 Qed.
 
 
-Program Definition extra_unsafe_transforms (impl_box impl_lazy_force : bool) :=
+Program Definition extra_unsafe_transforms (spec_inst impl_box impl_lazy_force : bool) :=
   let efl := EConstructorsAsBlocks.switch_cstr_as_blocks
   (EInlineProjections.disable_projections_env_flag (ERemoveParams.switch_no_params EWellformed.all_env_flags)) in
+  (* Instance/dictionary specialization runs first, in the same
+     constructors-as-blocks lambda-box regime as [implement_box], so that the
+     subsequent betared (in [optional_unsafe_transforms]) and dead-argument
+     elimination can clean up the exposed dictionary plumbing. *)
+  ETransform.optional_self_transform spec_inst
+    (specialize_instances_transformation efl EImplementBox.block_wcbv_flags) ▷
   ETransform.optional_self_transform impl_box implement_box_transformation ▷
   ETransform.optional_self_transform impl_lazy_force implement_lazy_force_transformation.
-Final Obligation.
+Next Obligation.
   cbn. intros.
-  destruct impl_box, impl_lazy_force; auto.
-  - cbn in *. apply switch_off_box_wf_eprogram. assumption.
-  - cbn in *. apply switch_off_box_wf_eprogram. assumption.
+  destruct spec_inst, impl_box, impl_lazy_force; cbn in *;
+    try assumption; try (apply switch_off_box_wf_eprogram; assumption).
+Qed.
+Next Obligation.
+  cbn. intros.
+  destruct spec_inst, impl_box, impl_lazy_force; cbn in *;
+    try assumption; try (apply switch_off_box_wf_eprogram; assumption).
 Qed.
 
 
 
 Program Definition untyped_transform_pipeline {guard : abstract_guard_impl}
-  (efl := all_env_flags) econf impl_box impl_lazy_force
+  (efl := all_env_flags) econf spec_inst impl_box impl_lazy_force
   : Transform.t _ _ _ EAst.term _ _
    (* Standard evaluation, with cases on prop, guarded fixpoints, applied constructors *)
    (eval_eprogram_mapping EWcbvEval.default_wcbv_flags)
@@ -154,7 +165,7 @@ Program Definition untyped_transform_pipeline {guard : abstract_guard_impl}
   rebuild_wf_env_transform_mapping true true ▷
   verified_lambdabox_pipeline_mapping ▷
   optional_unsafe_transforms econf ▷
-  extra_unsafe_transforms impl_box impl_lazy_force.
+  extra_unsafe_transforms spec_inst impl_box impl_lazy_force.
 Next Obligation.
   cbn. intros.
   destruct H as [? [? ?]].
@@ -170,7 +181,7 @@ Final Obligation.
   cbn. intros.
   destruct enable_unsafe.
   cbn in H.
-  destruct betared, impl_box, impl_lazy_force; auto.
+  destruct betared, spec_inst, impl_box, impl_lazy_force; auto.
 Qed.
 
 
@@ -333,7 +344,7 @@ Qed.
 
 
 Program Definition typed_to_untyped_transform_pipeline {guard : abstract_guard_impl}
-  (efl := EWellformed.all_env_flags) econf impl_box impl_lazy_force
+  (efl := EWellformed.all_env_flags) econf spec_inst impl_box impl_lazy_force
   : Transform.t _ _ _ _ _ _
    (eval_typed_eprogram_mapping EWcbvEval.default_wcbv_flags)
    (EProgram.eval_eprogram final_wcbv_flags) :=
@@ -342,7 +353,7 @@ Program Definition typed_to_untyped_transform_pipeline {guard : abstract_guard_i
    trans_env_transform ▷
    rebuild_wf_env_transform_mapping true true ▷
    verified_lambdabox_typed_pipeline econf ▷
-   extra_unsafe_transforms impl_box impl_lazy_force.
+   extra_unsafe_transforms spec_inst impl_box impl_lazy_force.
 Next Obligation.
   intros.
   cbn in *.
@@ -365,12 +376,12 @@ Final Obligation.
   cbn. intros.
   destruct enable_unsafe.
   cbn in H.
-  destruct betared, impl_box, impl_lazy_force; auto.
+  destruct betared, spec_inst, impl_box, impl_lazy_force; auto.
 Qed.
 
 
-Program Definition run_untyped_transforms econf ind_reorder impl_box impl_lazy_force p :=
-  run (untyped_transform_pipeline econf impl_box impl_lazy_force) (ind_reorder, p) _.
+Program Definition run_untyped_transforms econf ind_reorder spec_inst impl_box impl_lazy_force p :=
+  run (untyped_transform_pipeline econf spec_inst impl_box impl_lazy_force) (ind_reorder, p) _.
 Final Obligation.
 Admitted. (* assumed for now, check_wf should ensure this *)
 
@@ -379,7 +390,7 @@ Program Definition run_typed_transforms econf ind_reorder p :=
 Final Obligation.
 Admitted. (* assumed for now, check_wf should ensure this *)
 
-Program Definition run_typed_to_untyped_transforms econf ind_reorder impl_box impl_lazy_force p :=
-  run (typed_to_untyped_transform_pipeline econf impl_box impl_lazy_force) (ind_reorder, p) _.
+Program Definition run_typed_to_untyped_transforms econf ind_reorder spec_inst impl_box impl_lazy_force p :=
+  run (typed_to_untyped_transform_pipeline econf spec_inst impl_box impl_lazy_force) (ind_reorder, p) _.
 Final Obligation.
 Admitted. (* assumed for now, check_wf should ensure this *)

--- a/theories/serialization/DeserializeConfig.v
+++ b/theories/serialization/DeserializeConfig.v
@@ -216,13 +216,13 @@ Instance Deserialize_custom_attributes : Deserialize custom_attributes :=
 Instance Deserialize_erasure_phases : Deserialize erasure_phases :=
   fun l e =>
     Deser.match_con "erasure_phases" []
-      [ ("erasure_phases", Deser.con7_ Build_erasure_phases) ]
+      [ ("erasure_phases", Deser.con8_ Build_erasure_phases) ]
       l e.
 
 Instance Deserialize_erasure_phases' : Deserialize erasure_phases' :=
   fun l e =>
     Deser.match_con "erasure_phases" []
-      [ ("erasure_phases", Deser.con7_ Build_erasure_phases') ]
+      [ ("erasure_phases", Deser.con8_ Build_erasure_phases') ]
       l e.
 
 Instance Deserialize_config : Deserialize config :=

--- a/theories/serialization/SerializeConfig.v
+++ b/theories/serialization/SerializeConfig.v
@@ -263,7 +263,8 @@ Instance Serialize_erasure_phases : Serialize erasure_phases :=
      to_sexp (betared o);
      to_sexp (unboxing o);
      to_sexp (dearg_ctors o);
-     to_sexp (dearg_consts o)
+     to_sexp (dearg_consts o);
+     to_sexp (specialize_instances o)
     ]%sexp.
 
 Instance Serialize_erasure_phases' : Serialize erasure_phases' :=
@@ -275,7 +276,8 @@ Instance Serialize_erasure_phases' : Serialize erasure_phases' :=
      to_sexp (betared' o);
      to_sexp (unboxing' o);
      to_sexp (dearg_ctors' o);
-     to_sexp (dearg_consts' o)
+     to_sexp (dearg_consts' o);
+     to_sexp (specialize_instances' o)
     ]%sexp.
 
 Instance Serialize_config : Serialize config :=

--- a/theories/serialization/SerializeConfigComplete.v
+++ b/theories/serialization/SerializeConfigComplete.v
@@ -413,7 +413,7 @@ Proof.
   intros l o.
   cbn -[Deserialize_bool].
   simpl_bytes.
-  rewrite 7!complete_class.
+  rewrite 8!complete_class.
   destruct o; cbn.
   reflexivity.
 Qed.
@@ -424,7 +424,7 @@ Proof.
   intros l o.
   cbn -[Deserialize_bool].
   simpl_bytes.
-  rewrite 7!complete_class.
+  rewrite 8!complete_class.
   destruct o; cbn.
   reflexivity.
 Qed.

--- a/theories/serialization/SerializeConfigSound.v
+++ b/theories/serialization/SerializeConfigSound.v
@@ -567,9 +567,10 @@ Proof.
   apply sound_class in Ea4.
   apply sound_class in Ea5.
   apply sound_class in Ea6.
+  apply sound_class in Ea7.
   unfold to_sexp, Serialize_erasure_phases.
   cbn.
-  rewrite <- Ea0, <- Ea1, <- Ea2, <- Ea3, <- Ea4, <- Ea5, <- Ea6.
+  rewrite <- Ea0, <- Ea1, <- Ea2, <- Ea3, <- Ea4, <- Ea5, <- Ea6, <- Ea7.
   reflexivity.
 Qed.
 
@@ -588,9 +589,10 @@ Proof.
   apply sound_class in Ea4.
   apply sound_class in Ea5.
   apply sound_class in Ea6.
+  apply sound_class in Ea7.
   unfold to_sexp, Serialize_erasure_phases'.
   cbn.
-  rewrite <- Ea0, <- Ea1, <- Ea2, <- Ea3, <- Ea4, <- Ea5, <- Ea6.
+  rewrite <- Ea0, <- Ea1, <- Ea2, <- Ea3, <- Ea4, <- Ea5, <- Ea6, <- Ea7.
   reflexivity.
 Qed.
 


### PR DESCRIPTION
Merges the Lean 4 backend line (`fix-tests`) with the native-i64 / mixed-representation Rust backends and the Hindley-Milner bridge, so a single binary carries all fifteen verbs (`ast c cakeml compile elm eval help lean ocaml rust rustb rustm rustm2 validate wasm`), plus a new `rustu`.

## What this branch adds on top of `fix-tests`

- **Native-i64 (`rustb`), mixed-representation (`rustm`, `rustm2`) Rust backends** and their coherence proof, and the HM inference wiring.
- **`rustu`** — Rust with no numeric remapping, so `nat`/`positive`/`N`/`Z` are extracted as inductives. This is the Rust configuration whose runtimes are comparable with the C/OCaml/Wasm/CakeML/Lean backends, since it is the same erased program they run; `rust` (GMP) and `rustb` (native i64) replace the program rather than its code generator.
- **P4 dearging** removes dead type-args and all-live ctor masks; **P5** parameterizes the mixed partition.

## Merge resolution

The two sides only added backends. Four textual conflicts were unions (the verb list in `bin/main.ml`, the extraction list in `theories/Extraction.v`, `.gitignore`). In `Pipeline.validate_ast_type` the relaxation that lets Rust and Elm accept untyped input via the HM section is kept, and `Lean` is added to the untyped-accepting arm. One semantic conflict: `LeanBackend.v`'s `erasure_phases_config` predated the `specialize_instances_c` field this line adds to the record, so it now sets `specialize_instances_c := Compatible false`, matching the other untyped backends.

## Verified

- `make -f RocqMakefile` and `dune build` both green on switch `peregrine-9.1` (Rocq 9.1.1).
- Correctness across the benchmark suite: C, OCaml, Wasm, CakeML, Lean all 26/26; `rustu` 24/26 (VsEasy/VsHard fail on VeriStar's polymorphic `mergeC`, a pre-existing typed-extraction printer gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
